### PR TITLE
Overhaul of the mute system

### DIFF
--- a/src/main/java/net/irisshaders/lilybot/LilyBot.java
+++ b/src/main/java/net/irisshaders/lilybot/LilyBot.java
@@ -117,6 +117,8 @@ public class LilyBot {
 
         INSTANCE.addBuiltinCommands(builder);
         INSTANCE.addCustomCommands(builder);
+
+        Mute.rescheculeMutes();
     }
 
     public void addBuiltinCommands(CommandClient commands) {

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Mute.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Mute.java
@@ -2,23 +2,32 @@ package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.ButtonClickEvent;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.dv8tion.jda.api.interactions.Interaction;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import net.irisshaders.lilybot.LilyBot;
+import net.irisshaders.lilybot.database.SQLiteDataSource;
 import net.irisshaders.lilybot.utils.Constants;
-import net.irisshaders.lilybot.utils.Memory;
+import net.irisshaders.lilybot.utils.DateHelper;
 
 import java.awt.*;
+import java.sql.Connection;
+import java.util.Date;
+import java.util.HashMap;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -43,80 +52,27 @@ public class Mute extends SlashCommand {
     @Override
     protected void execute(SlashCommandEvent event) {
 
-        TextChannel actionLog = event.getGuild().getTextChannelById(Constants.ACTION_LOG);
         Member target = event.getOption("member").getAsMember();
         User user = event.getUser();
-        JDA jda = event.getJDA();
-        Guild guild = jda.getGuildById(Constants.GUILD_ID);
         String reason = event.getOption("reason") == null ? "No reason provided" : event.getOption("reason").getAsString();
         String duration = event.getOption("duration") == null ? "6h" : event.getOption("duration").getAsString();
-        Role mutedRole = guild.getRoleById(Constants.MUTED_ROLE);
+        MuteEntry currentMute = getCurrentMutes().get(target);
 
-        if (!target.getRoles().contains(mutedRole)) {
+        if (currentMute == null) { // User is not muted
 
-            MessageEmbed userEmbed = new EmbedBuilder()
-                    .setTitle("You were muted")
-                    .addField(String.format("You are muted from %s for:", guild.getName()), duration, false)
-                    .addField("Reason:", reason, false)
-                    .setColor(Color.CYAN)
-                    .setFooter("Muted by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
-                    .build();
+            Timestamp expiry = Timestamp.from(Instant.now().plusSeconds(parseDuration(duration)));
+            MuteEntry mute = new MuteEntry(target, user, expiry, reason);
+            mute(mute, event);
 
-            MessageEmbed muteEmbed = new EmbedBuilder()
-                    .setTitle("Mute")
-                    .addField("Muted:", target.getUser().getAsMention(), false)
-                    .addField("Muted for:", duration, false)
-                    .addField("Reason:", reason, false)
-                    .setColor(Color.CYAN)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
-                    .build();
 
-            MessageEmbed unmuteEmbed = new EmbedBuilder()
-                    .setTitle("Unmute")
-                    .addField("Unmuted:", target.getUser().getAsMention(), false)
-                    .addField("Reason:", "The duration of the mute is over.", false)
-                    .setColor(Color.CYAN)
-                    .setFooter("Mute was originally requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
-                    .build();
-
-            int durationInt = parseDuration(duration);
-
-            // Send the embed as Interaction reply, in action log and to the user
-            event.replyEmbeds(muteEmbed).mentionRepliedUser(false).setEphemeral(true).submit();
-            actionLog.sendMessageEmbeds(muteEmbed).queue();
-            target.getUser().openPrivateChannel()
-                    .flatMap(privateChannel -> privateChannel.sendMessageEmbeds(userEmbed))
-                    .queue(null, throwable -> {
-                        MessageEmbed failedToDMEmbed = new EmbedBuilder()
-                                .setTitle("Failed to DM " + target.getUser().getAsTag() + " for mute.")
-                                .setColor(Color.CYAN)
-                                .setFooter("Mute was originally requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                                .setTimestamp(Instant.now())
-                                .build();
-                        actionLog.sendMessageEmbeds(failedToDMEmbed).queue();
-                    });
-
-            guild.addRoleToMember(target, mutedRole).queue();
-
-            new Timer().schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    guild.removeRoleFromMember(target, mutedRole).queue(
-                            success -> actionLog.sendMessageEmbeds(unmuteEmbed).queue(),
-                            error -> event.replyFormat("Unable to mute %s: %s", target.getUser().getName(), error).mentionRepliedUser(false).setEphemeral(false).submit()
-                    );
-                }
-            }, durationInt);
-
-        } else if (target.getRoles().contains(mutedRole)) {
-
+        } else { // User is muted, ask for unmuting
             MessageEmbed alreadyMutedEmbed = new EmbedBuilder()
                     .setTitle("Already muted")
                     .setDescription("Do you want to unmute? Respond with the buttons below.")
                     .addField("The following member is already muted:", target.getUser().getAsTag(), false)
+                    .addField("Mute reason:", currentMute.reason(), false)
+                    .addField("Muted by:", currentMute.requester().getAsTag(), false)
+                    .addField("Expires at", DateHelper.formatDateAndTime(currentMute.expiry()), false)
                     .setColor(Color.CYAN)
                     .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
                     .setTimestamp(Instant.now())
@@ -137,20 +93,7 @@ public class Mute extends SlashCommand {
                 switch (id) {
 
                     case "yes" -> {
-
-                        MessageEmbed unmuteEmbed = new EmbedBuilder()
-                                .setTitle("Unmute")
-                                .addField("Unmuted:", target.getUser().getAsMention(), false)
-                                .addField("Reason:", "Manual Unmuted by " + buttonClickEventUser.getAsTag(), false)
-                                .setColor(Color.CYAN)
-                                .setFooter("Requested by " + buttonClickEventUser.getAsTag(), buttonClickEventUser.getEffectiveAvatarUrl())
-                                .setTimestamp(Instant.now())
-                                .build();
-
-                        buttonClickEvent.replyEmbeds(unmuteEmbed).mentionRepliedUser(false).setEphemeral(true).submit();
-                        actionLog.sendMessageEmbeds(unmuteEmbed).queue();
-
-                        guild.removeRoleFromMember(target, mutedRole).queue();
+                        unmute(currentMute, "Manually unmuted by " + buttonClickEventUser.getAsTag(), buttonClickEvent);
 
                     }
                     case "no" -> {
@@ -174,23 +117,199 @@ public class Mute extends SlashCommand {
 
     }
 
-    public static Integer parseDuration(String time) {
+    /**
+     * Mutes a member, messages them about it, prints to the action log and replies to the given interaction<p>
+     * This method is also called from {@link Warn}.<p>
+     * If the {@link Member} is already muted, the database will throw an exception
+     * @param mute The {@link MuteEntry} to get all the data from
+     * @param interaction The interaction to reply to, or {@code null} to not reply to any event
+     */
+    public static void mute(MuteEntry mute, Interaction interaction) {
+        Guild guild = LilyBot.INSTANCE.jda.getGuildById(Constants.GUILD_ID);
+        TextChannel actionLog = LilyBot.INSTANCE.jda.getTextChannelById(Constants.ACTION_LOG);
+        Role mutedRole = LilyBot.INSTANCE.jda.getRoleById(Constants.MUTED_ROLE);
+        
+        MessageEmbed muteEmbed = new EmbedBuilder()
+                .setTitle("Mute")
+                .addField("Muted:", mute.target().getUser().getAsMention(), false)
+                .addField("Muted until:", DateHelper.formatRelative(mute.expiry()), false)
+                .addField("Reason:", mute.reason(), false)
+                .setColor(Color.CYAN)
+                .setFooter("Requested by " + mute.requester().getAsTag(), mute.requester().getEffectiveAvatarUrl())
+                .setTimestamp(Instant.now())
+                .build();
+        MessageEmbed userEmbed = new EmbedBuilder()
+                .setTitle("You were muted")
+                .addField(String.format("You are muted from %s until:", guild.getName()), DateHelper.formatRelative(mute.expiry()), false)
+                .addField("Reason:", mute.reason(), false)
+                .setColor(Color.CYAN)
+                .setFooter("Muted by " + mute.requester().getAsTag(), mute.requester().getEffectiveAvatarUrl())
+                .setTimestamp(Instant.now())
+                .build();
+        
+        // Send the embed as Interaction reply, in action log and to the user
+        if (interaction != null) { // There may not be an event if this is a consequence of warn points
+            interaction.replyEmbeds(muteEmbed).mentionRepliedUser(false).setEphemeral(true).submit();
+        }
+        actionLog.sendMessageEmbeds(muteEmbed).queue();
+        
+        mute.target().getUser().openPrivateChannel()
+            .flatMap(privateChannel -> privateChannel.sendMessageEmbeds(userEmbed))
+            .queue(null, throwable -> {
+                MessageEmbed failedToDMEmbed = new EmbedBuilder()
+                        .setTitle("Failed to DM " + mute.target().getUser().getAsTag() + " for mute.")
+                        .setColor(Color.CYAN)
+                        .setFooter("Mute was requested by " + mute.requester().getAsTag(), mute.requester().getEffectiveAvatarUrl())
+                        .setTimestamp(Instant.now())
+                        .build();
+            actionLog.sendMessageEmbeds(failedToDMEmbed).queue();
+        });
+
+        guild.addRoleToMember(mute.target(), mutedRole).queue();
+
+        insertMuteToDb(mute);
+        new Timer().schedule(new TimerTask() {
+            @Override
+            public void run() {
+                unmute(mute, "The duration of the mute is over", null);
+            }
+        }, mute.expiry());
+    }
+
+    /**
+     * Converts a duration string to a duration in seconds.
+     * Also used in {@link Warn}
+     */
+    public static int parseDuration(String time) {
         int duration = Integer.parseInt(time.replaceAll("[^0-9]", ""));
         String unit = time.replaceAll("[^A-Za-z]+", "").trim();
         switch (unit) {
             // I know this is cursed, but I do not care, it works
-            case "s" -> duration *= 1000;
-            case "m", "min" -> duration *= 60000;
-            case "h", "hour" -> duration *= 3600000;
-            case "d", "day" -> duration *= 86400000;
+            case "s" -> duration *= 1;
+            case "m", "min" -> duration *= 60;
+            case "h", "hour" -> duration *= 3600;
+            case "d", "day" -> duration *= 86400;
         }
         return duration;
     }
 
+    /**
+     * Unmutes the user from the {@link MuteEntry} and logs it to the action log, and as an interaction response if interaction isn't {@code null}
+     * @param mute The {@link MuteEntry} to get the data from. Ignores everything but target and requester
+     * @param reason The reason of the unmute
+     * @param interaction The interaction to notify about the unmute, or {@code null} if there's none
+     */
+    private static void unmute(MuteEntry mute, String reason, Interaction interaction) {
+        Guild guild = LilyBot.INSTANCE.jda.getGuildById(Constants.GUILD_ID);
+        TextChannel actionLog = LilyBot.INSTANCE.jda.getTextChannelById(Constants.ACTION_LOG);
+        
+        MessageEmbed unmuteEmbed = new EmbedBuilder()
+                .setTitle("Unmute")
+                .addField("Unmuted:", mute.target().getUser().getAsMention(), false)
+                .addField("Reason:", reason, false)
+                .setColor(Color.CYAN)
+                .setFooter("Mute was originally requested by " + mute.requester().getAsTag(), mute.requester().getEffectiveAvatarUrl())
+                .setTimestamp(Instant.now())
+                .build();
+        
+        guild.removeRoleFromMember(mute.target(), LilyBot.INSTANCE.jda.getRoleById(Constants.MUTED_ROLE)).queue(
+                success -> {
+                    actionLog.sendMessageEmbeds(unmuteEmbed).queue();
+                    if (interaction != null) {
+                        interaction.replyEmbeds(unmuteEmbed).mentionRepliedUser(false).setEphemeral(true).submit();
+                    }
+                },
+                error -> {
+                    MessageEmbed errorEmbed = new EmbedBuilder()
+                            .setTitle(String.format("Unable to unmute %s:", mute.target().getUser().getName()))
+                            .appendDescription(error.toString())
+                            .setColor(Color.RED)
+                            .build();
+                    actionLog.sendMessageEmbeds(errorEmbed).submit();
+                    if (interaction != null) {
+                        interaction.replyEmbeds(unmuteEmbed).mentionRepliedUser(false).setEphemeral(true).submit();
+                    }
+                    error.printStackTrace();
+                }
+        );
+        removeUserFromDb(mute.target().getId());
+    }
+
+    private static void insertMuteToDb(MuteEntry mute) {
+        try (Connection connection = SQLiteDataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement("INSERT INTO mute(id, expiry, requester, reason) VALUES (?, ?, ?, ?)")) {
+            ps.setString(1, mute.target().getId());
+            ps.setTimestamp(2, mute.expiry());
+            ps.setString(3, mute.requester().getId());
+            ps.setString(4, mute.reason());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    private static void removeUserFromDb(String targetId) {
+        try (Connection connection = SQLiteDataSource.getConnection();
+                PreparedStatement ps = connection.prepareStatement("DELETE FROM mute WHERE id=?")) {
+               ps.setString(1, targetId);
+               ps.executeUpdate();
+           } catch (SQLException e) {
+               e.printStackTrace();
+           }
+    }
 
     private boolean equalsAny(String id) {
         return id.equals("mute:yes") ||
                 id.equals("mute:no");
     }
+
+    /**
+     * Re-schedules all saved mutes, and unmutes all expired mutes
+     */
+    public static void rescheculeMutes() {
+        for (MuteEntry mute : getCurrentMutes().values()) {
+            if (mute.expiry().before(Date.from(Instant.now()))) {
+                unmute(mute, "The duration of the mute was over while the bot wasn't running", null); // Already expired
+            } else {
+                new Timer().schedule(new TimerTask() {
+                    @Override
+                    public void run() {
+                        unmute(mute, "The duration of the mute is over", null);
+                    }
+                }, mute.expiry());
+            }
+        }
+    }
+
+    /**
+     * Gets a {@link Map} mapping {@link Member} to their {@link MuteEntry}, for all active maps
+     */
+    public static Map<Member, MuteEntry> getCurrentMutes() {
+        Guild guild = LilyBot.INSTANCE.jda.getGuildById(Constants.GUILD_ID);
+        Map<Member, MuteEntry> mutes = new HashMap<>();
+
+        try (Connection connection = SQLiteDataSource.getConnection();
+             PreparedStatement ps = connection.prepareStatement("SELECT * FROM mute")) {
+            ResultSet queryResult = ps.executeQuery();
+            while (queryResult.next()) {
+                Member target = guild.getMemberById(queryResult.getString("id"));
+                User requester = LilyBot.INSTANCE.jda.getUserById(queryResult.getString("requester"));
+                Timestamp expiry = queryResult.getTimestamp("expiry");
+                String reason = queryResult.getString("reason");
+                mutes.put(target, new MuteEntry(target, requester, expiry, reason));
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return mutes;
+    }
+    
+    /**
+     * 
+     * @param target The target that was muted
+     * @param requester The requester of the mute, that may come from a warn
+     *
+     */
+    public static record MuteEntry(Member target, User requester, Timestamp expiry, String reason) {}
 
 }

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/MuteList.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/MuteList.java
@@ -2,16 +2,16 @@ package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
 import net.dv8tion.jda.api.EmbedBuilder;
-import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+import net.irisshaders.lilybot.commands.moderation.Mute.MuteEntry;
 import net.irisshaders.lilybot.utils.Constants;
+import net.irisshaders.lilybot.utils.DateHelper;
 
 import java.awt.*;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 
 @SuppressWarnings("ConstantConditions")
 public class MuteList extends SlashCommand {
@@ -28,16 +28,8 @@ public class MuteList extends SlashCommand {
 
     @Override
     protected void execute(SlashCommandEvent event) {
-
-        JDA jda = event.getJDA();
-        Guild guild = jda.getGuildById(Constants.GUILD_ID);
-        Role mutedRole = guild.getRoleById(Constants.MUTED_ROLE);
         User user = event.getUser();
-        List<Member> guildMembers = guild.getMembers();
-        List<String> mutedMembers = new ArrayList<>();
-
-        guildMembers.stream().filter(member -> member.getRoles().contains(mutedRole))
-                .forEach(member -> mutedMembers.add(member.getAsMention()));
+        Collection<MuteEntry> mutedMembers = Mute.getCurrentMutes().values();
 
         if (mutedMembers.isEmpty()) {
 
@@ -52,16 +44,20 @@ public class MuteList extends SlashCommand {
 
         } else {
 
-            MessageEmbed muteListEmbed = new EmbedBuilder()
+            EmbedBuilder muteListEmbedBuilder = new EmbedBuilder()
                     .setTitle("Mute List")
-                    .setDescription(String.format("These are the muted members:\n %s", mutedMembers)
-                            .replace("[", "").replace("]", ""))
+                    .setDescription("These are the muted members:")
                     .setColor(Color.CYAN)
                     .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
-                    .build();
+                    .setTimestamp(Instant.now());
+            for (MuteEntry mute: mutedMembers) {
+                muteListEmbedBuilder.addField("User:", mute.target().getUser().getAsTag(), false);
+                muteListEmbedBuilder.addField("Muted by:", mute.requester().getAsTag(), true);
+                muteListEmbedBuilder.addField("Expires:", DateHelper.formatDateAndTime(mute.expiry()), true);
+                muteListEmbedBuilder.addField("Reason:", mute.reason(), true);
+            }
 
-            event.replyEmbeds(muteListEmbed).mentionRepliedUser(false).setEphemeral(true).queue();
+            event.replyEmbeds(muteListEmbedBuilder.build()).mentionRepliedUser(false).setEphemeral(true).queue();
 
         }
 

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Warn.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Warn.java
@@ -7,6 +7,7 @@ import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.InteractionHook;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.irisshaders.lilybot.commands.moderation.Mute.MuteEntry;
 import net.irisshaders.lilybot.database.SQLiteDataSource;
 import net.irisshaders.lilybot.utils.Constants;
 import net.irisshaders.lilybot.utils.ResponseHelper;
@@ -16,11 +17,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 
 @SuppressWarnings("ConstantConditions")
 public class Warn extends SlashCommand {
@@ -48,7 +48,6 @@ public class Warn extends SlashCommand {
         User user = event.getUser();
         InteractionHook hook = event.getHook();
         Guild guild = event.getGuild();
-        Role mutedRole = guild.getRoleById(Constants.MUTED_ROLE);
         TextChannel actionLog = guild.getTextChannelById(Constants.ACTION_LOG);
 
         event.deferReply(true).queue();
@@ -58,7 +57,7 @@ public class Warn extends SlashCommand {
         // UPDATE Target's points with the given points
         updateUsers(points, targetId);
         // SELECT points from target, executes upon reaching a threshold
-        readPoints(target, points, hook, reason, user, actionLog, guild, mutedRole);
+        readPoints(target, points, hook, reason, user, actionLog, guild);
 
     }
 
@@ -104,12 +103,13 @@ public class Warn extends SlashCommand {
      * @param guild The guild where this took place. (Guild)
      * @param mutedRole The role to give for a mute. (Role)
      */
-    private void readPoints(Member target, String points, InteractionHook hook, String reason, User user, TextChannel actionLog, Guild guild, Role mutedRole) {
+    private void readPoints(Member target, String points, InteractionHook hook, String reason, User user, TextChannel actionLog, Guild guild) {
+        int totalPoints = 0;
         try (Connection connection = SQLiteDataSource.getConnection();
              PreparedStatement ps = connection.prepareStatement("SELECT points FROM warn WHERE id = (?)")) {
             ps.setString(1, target.getId());
             ResultSet resultSet = ps.executeQuery();
-            int totalPoints = resultSet.getInt("points");
+            totalPoints = resultSet.getInt("points");
             MessageEmbed warnEmbed = new EmbedBuilder()
                     .setTitle(target.getUser().getAsTag() + " was given " + points + " points!")
                     .setColor(Color.CYAN)
@@ -124,11 +124,10 @@ public class Warn extends SlashCommand {
             target.getUser().openPrivateChannel()
                     .flatMap(privateChannel -> privateChannel.sendMessageEmbeds(warnEmbed))
                     .queue(null, throwable -> System.out.println());
-            consequences(target, reason, user, actionLog, guild, mutedRole, totalPoints);
-            ps.executeQuery();
         } catch (SQLException e) {
             e.printStackTrace();
         }
+        consequences(target, reason, user, actionLog, guild, totalPoints);
     }
 
     /**
@@ -141,52 +140,30 @@ public class Warn extends SlashCommand {
      * @param mutedRole The role to give for a mute. (Guild)
      * @param totalPoints The total number of points in the database. (int)
      */
-    private void consequences(Member target, String reason, User user, TextChannel actionLog, Guild guild, Role mutedRole, int totalPoints) {
-        if (totalPoints >= 50 && totalPoints < 50) { // 1 hr mute
-            mute(guild, target, mutedRole, "1h", user, actionLog);
-        } else if (totalPoints >= 50 && totalPoints < 100) { // 3 hr mute
-            mute(guild, target, mutedRole, "3h", user, actionLog);
+    private void consequences(Member target, String reason, User user, TextChannel actionLog, Guild guild, int totalPoints) {
+        if (totalPoints >= 50 && totalPoints < 100) { // 3 hr mute
+            mute(target, "3h", user);
         } else if (totalPoints >= 100 && totalPoints < 150) { // 12 hr mute
-            mute(guild, target, mutedRole, "12h", user, actionLog);
+            mute(target, "12h", user);
         } else if (totalPoints >= 150) { // ban
             ban(target, user, actionLog, reason);
         }
     }
 
     /**
-     * A method for giving out mutes.
-     * @param guild The guild where this took place. (Guild)
+     * An utility method for giving mutes from here. Basically calls {@link Mute#mute(MuteEntry, SlashCommandEvent)}.<p>
+     * It also checks if the {@link Member} is muted before muting
      * @param target The target. (Member)
-     * @param mutedRole The role to give for a mute. (Role)
      * @param duration The length of the mute. (String)
-     * @param user The user of the command. (User)
-     * @param actionLog Where the moderation messages are sent. (TextChannel)
+     * @param requester The user of the command. (User)
      */
-    private void mute(Guild guild, Member target, Role mutedRole, String duration, User user, TextChannel actionLog) {
-        target.getUser().openPrivateChannel()
-            .flatMap(privateChannel -> privateChannel.sendMessageEmbeds(new EmbedBuilder()
-                .setTitle("You were muted for " + duration + " as a result of being warned.")
-                .setColor(Color.CYAN)
-                .setFooter("Warn was issued by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now())
-                .build()))
-                .queue(null, throwable -> {
-                    actionLog.sendMessageEmbeds(ResponseHelper.genFailureEmbed(user, "Failed to DM " + target.getUser().getAsTag() + " for mute.", null)).queue();
-                });
-        actionLog.sendMessageEmbeds(new EmbedBuilder()
-                .setTitle(target.getUser().getAsTag() + " was muted for " + duration + " as a result of being warned.")
-                .setColor(Color.CYAN)
-                .setFooter("Warn was issued by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now())
-                .build())
-                .queue();
-        guild.addRoleToMember(target, mutedRole).queue();
-        new Timer().schedule(new TimerTask() {
-            @Override
-            public void run() {
-                guild.removeRoleFromMember(target, mutedRole).queue();
-            }
-        }, Mute.parseDuration(duration));
+    private void mute(Member target, String duration, User requester) {
+        if (Mute.getCurrentMutes().containsKey(target)) { // Currently muted
+            return; // Do nothing. The warn was already notified, and there just was no mute since the user is already muted
+        }
+        Timestamp expiry = Timestamp.from(Instant.now().plusSeconds(Mute.parseDuration(duration)));
+        MuteEntry mute = new MuteEntry(target, requester, expiry, "Being warned");
+        Mute.mute(mute, null);
     }
 
     /**

--- a/src/main/java/net/irisshaders/lilybot/database/SQLiteDataSource.java
+++ b/src/main/java/net/irisshaders/lilybot/database/SQLiteDataSource.java
@@ -6,8 +6,9 @@ import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -23,13 +24,10 @@ public class SQLiteDataSource {
 
     static {
         try {
-            File database = new File("database.db");
-            if (!database.exists()) {
-                if (database.createNewFile()) {
-                    LOGGER.info("Created database file!");
-                } else {
-                    LOGGER.error("Could not create database file!");
-                }
+            Path database = Path.of("database.db");
+            if (Files.notExists(database)) {
+                Files.createFile(database);
+                LOGGER.info("Created database file!");
             }
         } catch (IOException e) {
             e.printStackTrace();
@@ -47,7 +45,11 @@ public class SQLiteDataSource {
             @Language("SQL")
             String tableString = "CREATE TABLE IF NOT EXISTS warn(id INTEGER UNIQUE, points INTEGER)";
             statement.execute(tableString);
-            LOGGER.info("Table initialised!");
+            LOGGER.info("Warn table initialised!");
+            @Language("SQL")
+            String muteString = "CREATE TABLE IF NOT EXISTS mute(id INTEGER UNIQUE, expiry TIMESTAMP, requester INTEGER, reason TINYTEXT)";
+            statement.execute(muteString);
+            LOGGER.info("Mute table initialised!");
         } catch (SQLException e) {
             e.printStackTrace();
         }

--- a/src/main/java/net/irisshaders/lilybot/utils/DateHelper.java
+++ b/src/main/java/net/irisshaders/lilybot/utils/DateHelper.java
@@ -1,0 +1,21 @@
+package net.irisshaders.lilybot.utils;
+
+import java.util.Date;
+
+public class DateHelper {
+    /**
+     * Formats a {@link Date} instance into a {@link String} with the date and time using the new discord time thing
+     */
+    public static String formatDateAndTime(Date date) {
+        return "<t:"+ date.getTime()/1000+">";
+    }
+    
+    /**
+     * Formats a {@link Date} into a {@link String} to the relative time using the new discord time thing
+     * @param date
+     * @return
+     */
+    public static String formatRelative(Date date) {
+        return "<t:"+ date.getTime()/1000+":R>";
+    }
+}


### PR DESCRIPTION
Supersedes #14.

This PR overhauls the mute system a bit.

Most importantly, it saves the current mutes and expiry times to the database and restores them after restart, but also unifies all the code around muting and unmuting to use the same methods instead of having different ways of muting in the mute command and warn consequences.

Since it saves the data, the requester, expiry time and reason are kept available to be seen when running the command to unmute or the mute-list command.

Also introduces a method to get the muted users and the mute data, `Mute.getCurrentMutes()`, that may be useful later.

<details>
<summary>Screenshots because why not</summary>

![imagen](https://user-images.githubusercontent.com/17107132/135768917-51c34fe0-39ed-4333-8fcc-238dbb09a2d9.png)
![imagen](https://user-images.githubusercontent.com/17107132/135768944-0f7a69b8-f5ac-4316-8560-c4cb65f9e188.png)
![imagen](https://user-images.githubusercontent.com/17107132/135768954-96a17227-3a8b-4436-94d9-e032a4c8cc78.png)
![imagen](https://user-images.githubusercontent.com/17107132/135769068-d72224c8-0732-4be9-b091-f7c46fc18740.png)
![imagen](https://user-images.githubusercontent.com/17107132/135769093-e9141968-ffe8-4a7d-98bb-0703431caf3b.png)

</details>

