### PR TITLE
Update to JDA 5-ish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.github.aasmart:JDA:dbce81721f'
-    implementation 'com.github.chalkyjeans:JDA-Chewtils:feature~context-menus-SNAPSHOT'
+    implementation 'com.github.altrisi:JDA:68a46e84ee' // Context menus, revert to official when merged
+    implementation 'com.github.altrisi:JDA-Chewtils:96b65c4fd' // Updated to jda 5 with context menus
     implementation 'ch.qos.logback:logback-classic:1.2.6'
     implementation 'io.github.cdimascio:dotenv-java:2.2.0'
     implementation 'org.kohsuke:github-api:1.133'

--- a/src/main/java/net/irisshaders/lilybot/commands/custom/Custom.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/custom/Custom.java
@@ -22,7 +22,7 @@ public class Custom extends SlashCommand {
         this.help = help;
         this.defaultEnabled = true;
         this.guildOnly = false;
-        this.botPermissions = new Permission[]{ Permission.MESSAGE_WRITE };
+        this.botPermissions = new Permission[]{ Permission.MESSAGE_SEND };
         this.botMissingPermMessage = "The bot does not have the `MESSAGE WRITE` permission.";
         this.children = children;
     }

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Say.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Say.java
@@ -26,7 +26,7 @@ public class Say extends SlashCommand {
         this.defaultEnabled = false;
         this.enabledRoles = new String[]{Constants.MODERATOR_ROLE};
         this.guildOnly = true;
-        this.botPermissions = new Permission[]{Permission.MESSAGE_WRITE, Permission.MESSAGE_EMBED_LINKS};
+        this.botPermissions = new Permission[]{Permission.MESSAGE_SEND, Permission.MESSAGE_EMBED_LINKS};
         this.botMissingPermMessage = "The bot does not have the `MESSAGE WRITE` permission.";
         List<OptionData> optionData = new ArrayList<>();
         optionData.add(new OptionData(OptionType.STRING, "message", "What you want to send in the channel.").setRequired(true));

--- a/src/main/java/net/irisshaders/lilybot/events/AttachmentHandler.java
+++ b/src/main/java/net/irisshaders/lilybot/events/AttachmentHandler.java
@@ -5,7 +5,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.MessageChannel;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.components.Button;
 
@@ -21,7 +21,7 @@ import java.util.List;
 public class AttachmentHandler extends ListenerAdapter {
 
     @Override
-    public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
+    public void onMessageReceived(MessageReceivedEvent event) {
         Message message = event.getMessage();
         List<Message.Attachment> attachments = message.getAttachments();
         if (attachments.size() == 0) return;


### PR DESCRIPTION
Updates JDA to v5, including thread support, improved apis and more!

The easy diff here in the background contains updates to our JDA fork (for context menus, those seem to be coming soon to jda though) and to our jda chewtils fork, that I had to update to jda 5 and the context menus fork.

Pls merge, it's small diff, but many possibilities.