### PR TITLE
Fix scheduled mutes not being unscheduled after manual unmute

### DIFF
--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Shutdown.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Shutdown.java
@@ -13,11 +13,9 @@ import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import net.irisshaders.lilybot.LilyBot;
 import net.irisshaders.lilybot.utils.Constants;
-import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.time.Instant;
-import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("ConstantConditions")
 public class Shutdown extends SlashCommand {
@@ -70,18 +68,11 @@ public class Shutdown extends SlashCommand {
 
                     buttonClickEvent.editComponents().setEmbeds(finalShutdownEmbed).queue();
                     actionLog.sendMessageEmbeds(finalShutdownEmbed).queue();
-                    LoggerFactory.getLogger(Shutdown.class).info("Shutting down due to a request from " + buttonClickEventUser.getAsTag() + "!");
+                    LilyBot.LOG_LILY.info("Shutting down due to a request from " + buttonClickEventUser.getAsTag() + "!");
 
-                    // Wait for it to send the embed and respond to any other commands. Can be reduced to a lower number if testing allows for it.
-                    try { TimeUnit.SECONDS.sleep(10); } catch (InterruptedException e) { e.printStackTrace(); }
+                    Mute.cancelTimers(); // Cancels timers, since they block shutdown by nothing being left (since they are left)
 
-                    jda.shutdownNow();
-                    try {
-                        TimeUnit.SECONDS.sleep(3L);
-                    } catch (InterruptedException e) {
-                        e.printStackTrace();
-                    }
-                    System.exit(0);
+                    jda.shutdown();
 
                 }
                 case "no" -> {


### PR DESCRIPTION
And also make shutdown not... do... weird things!

This PR fixes manually unmuted users being unmuted again when the scheduled times comes by storing the `TimerTask`s mapped to members in the mute class, and at the same time reuses the timer instead of creating a new one for every mute (1 Timer = 1 thread).

And while I was at it (because I _really_ didn't like that code) I fixed the last things that blocked Java from stopping gracefully after calling JDA's shutdown method, and (after testing pretty much everything I knew of and even keeping a few buttons scheduled) now there's no need to call System.exit() or manually wait for anything, it'll just shut down in (way) under a minute normally.