### PR TITLE
Add a utility method to create embeds with the format used everywhere

### DIFF
--- a/src/main/java/net/irisshaders/lilybot/commands/Ping.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/Ping.java
@@ -5,9 +5,9 @@ import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
+import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
-import java.time.Instant;
 
 public class Ping extends SlashCommand {
 
@@ -23,29 +23,20 @@ public class Ping extends SlashCommand {
 
         User user = event.getUser();
 
-        MessageEmbed pingEmbed = new EmbedBuilder()
-                .setTitle("Ping!")
-                .setDescription("`Pong!` Shows the bot's ping!")
-                .setColor(Color.ORANGE)
-                .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now())
-                .build();
+        EmbedBuilder pingEmbed = ResponseHelper.responseEmbed("Ping!", user, Color.ORANGE)
+                .setDescription("`Pong!` Shows the bot's ping!");
 
-        event.replyEmbeds(pingEmbed).mentionRepliedUser(false).setEphemeral(false).queue(interactionHook -> event.getJDA().getRestPing().queue(restPing -> {
+        event.replyEmbeds(pingEmbed.build()).mentionRepliedUser(false).setEphemeral(false).queue(interactionHook -> event.getJDA().getRestPing().queue(restPing -> {
 
             Long gatewayPing = event.getJDA().getGatewayPing();
 
-            MessageEmbed finalPingEmbed = new EmbedBuilder()
-                    .setTitle("Ping!")
+            MessageEmbed finalPingEmbed = pingEmbed
                     .setDescription(String.format(
                             """
                             `Pong!` Showing the bot's ping!
                             Gateway Ping: `%s ms`
                             Rest Ping: `%s ms`
                             """, gatewayPing, restPing))
-                    .setColor(Color.ORANGE)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
                     .build();
 
             interactionHook.editOriginalEmbeds(finalPingEmbed).queue();

--- a/src/main/java/net/irisshaders/lilybot/commands/custom/Custom.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/custom/Custom.java
@@ -1,12 +1,11 @@
 package net.irisshaders.lilybot.commands.custom;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
+import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
-import java.time.Instant;
 import java.util.Properties;
 
 public class Custom extends SlashCommand {
@@ -63,12 +62,8 @@ public class Custom extends SlashCommand {
     protected void execute(SlashCommandEvent event) {
         var user = event.getUser();
 
-        var embed = new EmbedBuilder()
-                .setTitle(this.title)
+        var embed = ResponseHelper.responseEmbed(this.title, user, this.color)
                 .setDescription(this.desc)
-                .setColor(this.color)
-                .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now())
                 .build();
 
         event.replyEmbeds(embed).mentionRepliedUser(false).setEphemeral(false).queue();

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Ban.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Ban.java
@@ -1,7 +1,6 @@
 package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
@@ -15,7 +14,6 @@ import net.irisshaders.lilybot.utils.Constants;
 import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,20 +59,16 @@ public class Ban extends SlashCommand {
 
         member.ban(days, reason).queue(unused -> {
 
-            MessageEmbed banEmbed = new EmbedBuilder()
-                    .setTitle("Banned a member.")
-                    .setColor(Color.CYAN)
+            MessageEmbed banEmbed = ResponseHelper.responseEmbed("Banned a member.", user, Color.CYAN)
                     .addField("Banned:", member.getUser().getAsTag(), false)
                     .addField("Days of messages deleted:", String.valueOf(days), false)
                     .addField("Reason:", reason, false)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
                     .build();
 
             event.replyEmbeds(banEmbed).mentionRepliedUser(false).setEphemeral(true).queue();
             actionLog.sendMessageEmbeds(banEmbed).queue();
 
-        }, throwable -> event.replyEmbeds(ResponseHelper.genFailureEmbed(user, "Failed to ban.", null))
+        }, throwable -> event.replyEmbeds(ResponseHelper.genFailureEmbed(user, "Failed to ban " + user.getAsTag(), null))
                             .mentionRepliedUser(false).setEphemeral(true).queue()
         );
 

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/BotActivity.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/BotActivity.java
@@ -1,7 +1,6 @@
 package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Activity;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -10,9 +9,9 @@ import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.irisshaders.lilybot.utils.Constants;
+import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,14 +38,8 @@ public class BotActivity extends SlashCommand{
         String option = event.getOption("status").getAsString();
 
         event.getJDA().getPresence().setActivity(Activity.playing(option));
-        MessageEmbed embed = new EmbedBuilder()
-                .setTitle("Changed Custom Status!")
-                .setDescription(
-                        "Changed Custom Status to " + option
-                )
-                .setColor(Color.RED)
-                .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now())
+        MessageEmbed embed = ResponseHelper.responseEmbed("Changed Custom Status!", user, Color.RED)
+                .setDescription("Changed Custom Status to " + option)
                 .build();
         event.getGuild().getTextChannelById(Constants.ACTION_LOG).sendMessageEmbeds(embed).queue();
         event.replyEmbeds(embed).setEphemeral(true).queue();

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/CheckPoints.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/CheckPoints.java
@@ -1,7 +1,6 @@
 package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.InteractionHook;
@@ -9,13 +8,13 @@ import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.irisshaders.lilybot.database.SQLiteDataSource;
 import net.irisshaders.lilybot.utils.Constants;
+import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +27,7 @@ public class CheckPoints extends SlashCommand {
         this.enabledRoles = new String[]{Constants.MODERATOR_ROLE, Constants.TRIAL_MODERATOR_ROLE};
         this.guildOnly = true;
         List<OptionData> optionData = new ArrayList<>();
-        optionData.add(new OptionData(OptionType.USER, "member", "The member to warn.").setRequired(true));
+        optionData.add(new OptionData(OptionType.USER, "member", "The member to get points from.").setRequired(true));
         this.options = optionData;
     }
 
@@ -77,11 +76,8 @@ public class CheckPoints extends SlashCommand {
             ps.setString(1, target.getId());
             ResultSet resultSet = ps.executeQuery();
             totalPoints = resultSet.getInt("points");
-            MessageEmbed checkPointsEmbed = new EmbedBuilder()
+            MessageEmbed checkPointsEmbed = ResponseHelper.responseEmbed(user, Color.CYAN)
                     .setTitle(target.getUser().getAsTag() + " has " + totalPoints + " points!")
-                    .setColor(Color.CYAN)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
                     .build();
             hook.sendMessageEmbeds(checkPointsEmbed).mentionRepliedUser(false).queue();
         } catch (SQLException e) {

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Clear.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Clear.java
@@ -1,7 +1,6 @@
 package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.*;
 import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
@@ -11,7 +10,6 @@ import net.irisshaders.lilybot.utils.Constants;
 import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,12 +43,8 @@ public class Clear extends SlashCommand {
             List<Message> messageHistory = channel.getHistory().retrievePast(index).complete();
             channel.purgeMessages(messageHistory);
 
-            MessageEmbed deletedMessagesEmbed = new EmbedBuilder()
-                    .setTitle("Successfully deleted " + index + " messages from:")
+            MessageEmbed deletedMessagesEmbed = ResponseHelper.responseEmbed("Successfully deleted " + index + " messages from:", user, Color.GREEN)
                     .setDescription(String.format("<#%s>", id))
-                    .setColor(Color.GREEN)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
                     .build();
 
             event.replyEmbeds(deletedMessagesEmbed).mentionRepliedUser(false).setEphemeral(true).queue();

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Kick.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Kick.java
@@ -1,7 +1,6 @@
 package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Member;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -14,7 +13,6 @@ import net.irisshaders.lilybot.utils.Constants;
 import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,19 +43,15 @@ public class Kick extends SlashCommand {
 
         member.kick(reason).queue(unused -> {
 
-            MessageEmbed kickEmbed = new EmbedBuilder()
-                    .setTitle("Kicked a member")
+            MessageEmbed kickEmbed = ResponseHelper.responseEmbed("Kicked a member", user, Color.GREEN)
                     .addField("Kicked:", member.getUser().getAsTag(), false)
                     .addField("Reason:", reason, false)
-                    .setColor(Color.GREEN)
-                    .setFooter("Requested by " + user.getAsTag(), user.getAvatarUrl())
-                    .setTimestamp(Instant.now())
                     .build();
 
             event.replyEmbeds(kickEmbed).mentionRepliedUser(false).setEphemeral(true).queue();
             actionLog.sendMessageEmbeds(kickEmbed).queue();
 
-        }, throwable -> event.replyEmbeds(ResponseHelper.genFailureEmbed(user, "Failed to kick.", null))
+        }, throwable -> event.replyEmbeds(ResponseHelper.genFailureEmbed(user, "Failed to kick " + member.getUser().getAsTag(), null))
                 .mentionRepliedUser(false).setEphemeral(true).queue()
         );
 

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Mute.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Mute.java
@@ -17,6 +17,7 @@ import net.irisshaders.lilybot.LilyBot;
 import net.irisshaders.lilybot.database.SQLiteDataSource;
 import net.irisshaders.lilybot.utils.Constants;
 import net.irisshaders.lilybot.utils.DateHelper;
+import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
 import java.sql.Connection;
@@ -68,16 +69,12 @@ public class Mute extends SlashCommand {
             mute(mute, event);
 
         } else { // User is muted, ask for unmuting
-            MessageEmbed alreadyMutedEmbed = new EmbedBuilder()
-                    .setTitle("Already muted")
+            MessageEmbed alreadyMutedEmbed = ResponseHelper.responseEmbed("Already muted", user, Color.CYAN)
                     .setDescription("Do you want to unmute? Respond with the buttons below.")
                     .addField("The following member is already muted:", target.getUser().getAsTag(), false)
                     .addField("Mute reason:", currentMute.reason(), false)
                     .addField("Muted by:", currentMute.requester().getAsTag(), false)
                     .addField("Expires at", DateHelper.formatDateAndTime(currentMute.expiry()), false)
-                    .setColor(Color.CYAN)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
                     .build();
             String targetId = target.getId();
 
@@ -129,14 +126,10 @@ public class Mute extends SlashCommand {
         TextChannel actionLog = LilyBot.INSTANCE.jda.getTextChannelById(Constants.ACTION_LOG);
         Role mutedRole = LilyBot.INSTANCE.jda.getRoleById(Constants.MUTED_ROLE);
 
-        MessageEmbed muteEmbed = new EmbedBuilder()
-                .setTitle("Mute")
+        MessageEmbed muteEmbed = ResponseHelper.responseEmbed("Mute", mute.requester(), Color.CYAN)
                 .addField("Muted:", mute.target().getUser().getAsMention(), false)
                 .addField("Muted until:", DateHelper.formatRelative(mute.expiry()), false)
                 .addField("Reason:", mute.reason(), false)
-                .setColor(Color.CYAN)
-                .setFooter("Requested by " + mute.requester().getAsTag(), mute.requester().getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now())
                 .build();
         MessageEmbed userEmbed = new EmbedBuilder()
                 .setTitle("You were muted")
@@ -156,11 +149,8 @@ public class Mute extends SlashCommand {
         mute.target().getUser().openPrivateChannel()
             .flatMap(privateChannel -> privateChannel.sendMessageEmbeds(userEmbed))
             .queue(null, throwable -> {
-                MessageEmbed failedToDMEmbed = new EmbedBuilder()
+                MessageEmbed failedToDMEmbed = ResponseHelper.responseEmbed(mute.requester(), Color.CYAN)
                         .setTitle("Failed to DM " + mute.target().getUser().getAsTag() + " for mute.")
-                        .setColor(Color.CYAN)
-                        .setFooter("Mute was requested by " + mute.requester().getAsTag(), mute.requester().getEffectiveAvatarUrl())
-                        .setTimestamp(Instant.now())
                         .build();
             actionLog.sendMessageEmbeds(failedToDMEmbed).queue();
         });

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/MuteList.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/MuteList.java
@@ -9,9 +9,9 @@ import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.irisshaders.lilybot.commands.moderation.Mute.MuteEntry;
 import net.irisshaders.lilybot.utils.Constants;
 import net.irisshaders.lilybot.utils.DateHelper;
+import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
-import java.time.Instant;
 import java.util.Collection;
 
 public class MuteList extends SlashCommand {
@@ -34,23 +34,16 @@ public class MuteList extends SlashCommand {
 
         if (mutedMembers.isEmpty()) {
 
-            MessageEmbed noMutedMembers = new EmbedBuilder()
-                    .setTitle("There are no muted members.")
-                    .setColor(Color.CYAN)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
+            MessageEmbed noMutedMembers = ResponseHelper.responseEmbed(user, Color.CYAN) 
+                    .setDescription("There are no muted members.")
                     .build();
 
             event.replyEmbeds(noMutedMembers).mentionRepliedUser(false).setEphemeral(true).queue();
 
         } else {
 
-            EmbedBuilder muteListEmbedBuilder = new EmbedBuilder()
-                    .setTitle("Mute List")
-                    .setDescription("These are the muted members:")
-                    .setColor(Color.CYAN)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now());
+            EmbedBuilder muteListEmbedBuilder = ResponseHelper.responseEmbed("Muted Users", user, Color.CYAN)
+                    .setDescription("These are the muted members:");
             for (MuteEntry mute: mutedMembers) {
                 muteListEmbedBuilder.addField("User:", mute.target().getUser().getAsTag(), false);
                 muteListEmbedBuilder.addField("Muted by:", mute.requester().getAsTag(), true);

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Report.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Report.java
@@ -12,6 +12,8 @@ import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import net.irisshaders.lilybot.LilyBot;
 import net.irisshaders.lilybot.utils.Constants;
+import net.irisshaders.lilybot.utils.ResponseHelper;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
@@ -66,12 +68,8 @@ public class Report extends Command implements EventListener {
                 User user = event.getUser();
                 String id = event.getChannel().getId();
 
-                MessageEmbed reportEmbed = new EmbedBuilder()
-                        .setTitle("Report")
+                MessageEmbed reportEmbed = ResponseHelper.responseEmbed("Report Message", user, Color.RED)
                         .setDescription("Would you like to report this message? This will ping moderators, and false reporting will be treated as spam and punished accordingly.")
-                        .setColor(Color.RED)
-                        .setFooter("Requested by " + event.getUser().getAsTag(), user.getEffectiveAvatarUrl())
-                        .setTimestamp(Instant.now())
                         .build();
 
                 event.replyEmbeds(reportEmbed).addActionRow(

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Shutdown.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Shutdown.java
@@ -1,7 +1,6 @@
 package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.Emoji;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -13,10 +12,11 @@ import net.dv8tion.jda.api.interactions.components.Button;
 import net.dv8tion.jda.api.interactions.components.ButtonStyle;
 import net.irisshaders.lilybot.LilyBot;
 import net.irisshaders.lilybot.utils.Constants;
+import net.irisshaders.lilybot.utils.ResponseHelper;
+
 import org.slf4j.LoggerFactory;
 
 import java.awt.*;
-import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 @SuppressWarnings("ConstantConditions")
@@ -36,12 +36,8 @@ public class Shutdown extends SlashCommand {
         JDA jda = event.getJDA();
         TextChannel actionLog = jda.getTextChannelById(Constants.ACTION_LOG);
 
-        MessageEmbed shutdownEmbed = new EmbedBuilder()
-                .setTitle("Shut Down")
-                .setDescription("Do you want to shutdown the bot? Respond with the buttons below.")
-                .setColor(Color.RED)
-                .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now())
+        MessageEmbed shutdownEmbed = ResponseHelper.responseEmbed("Shut Down", user, Color.RED)
+                .setDescription("Do you really want to shutdown the bot?")
                 .build();
 
         event.replyEmbeds(shutdownEmbed).addActionRow(
@@ -60,12 +56,8 @@ public class Shutdown extends SlashCommand {
 
                 case "yes" -> {
 
-                    MessageEmbed finalShutdownEmbed = new EmbedBuilder()
-                            .setTitle("Shutting down...")
+                    MessageEmbed finalShutdownEmbed = ResponseHelper.responseEmbed("Shutting down...", buttonClickEventUser, Color.RED)
                             .setDescription("Note: It may take a few minutes for Discord to update my presence and say that I am offline.")
-                            .setColor(Color.RED)
-                            .setFooter("Requested by " + buttonClickEventUser.getAsTag(), buttonClickEventUser.getEffectiveAvatarUrl())
-                            .setTimestamp(Instant.now())
                             .build();
 
                     buttonClickEvent.editComponents().setEmbeds(finalShutdownEmbed).queue();
@@ -86,11 +78,8 @@ public class Shutdown extends SlashCommand {
                 }
                 case "no" -> {
 
-                    MessageEmbed noShutdownEmbed = new EmbedBuilder()
-                            .setTitle("Shutdown canceled")
-                            .setColor(Color.GREEN)
-                            .setFooter("Requested by " + buttonClickEventUser.getAsTag(), buttonClickEventUser.getEffectiveAvatarUrl())
-                            .setTimestamp(Instant.now())
+                    MessageEmbed noShutdownEmbed = ResponseHelper.responseEmbed(user, Color.GREEN)
+                            .setDescription("Shutdown canceled")
                             .build();
 
                     buttonClickEvent.editComponents().setEmbeds(noShutdownEmbed).queue();

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Unban.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Unban.java
@@ -1,7 +1,6 @@
 package net.irisshaders.lilybot.commands.moderation;
 
 import com.jagrosh.jdautilities.command.SlashCommand;
-import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.Permission;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.MessageEmbed;
@@ -14,7 +13,6 @@ import net.irisshaders.lilybot.utils.Constants;
 import net.irisshaders.lilybot.utils.ResponseHelper;
 
 import java.awt.*;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,12 +42,8 @@ public class Unban extends SlashCommand {
 
         guild.unban(userById).queue(unused -> {
 
-            MessageEmbed unbanEmbed = new EmbedBuilder()
-                    .setTitle("Unbanned a member.")
+            MessageEmbed unbanEmbed = ResponseHelper.responseEmbed("Unbanned a member", user, Color.CYAN)
                     .addField("Unbanned:", userById.getAsTag(), false)
-                    .setColor(Color.CYAN)
-                    .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                    .setTimestamp(Instant.now())
                     .build();
 
             event.replyEmbeds(unbanEmbed).mentionRepliedUser(false).setEphemeral(true).queue();

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Warn.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Warn.java
@@ -175,13 +175,9 @@ public class Warn extends SlashCommand {
      * @param reason The reason for the ban. (String)
      */
     private void ban(Member target, User user, TextChannel actionLog, String reason) {
-        MessageEmbed banEmbed = new EmbedBuilder()
-                .setTitle("Banned a member.")
-                .setColor(Color.CYAN)
+        MessageEmbed banEmbed = ResponseHelper.responseEmbed("Banned a member", user, Color.CYAN)
                 .addField("Banned:", target.getUser().getAsTag(), false)
                 .addField("Reason:", reason, false)
-                .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now())
                 .build();
         actionLog.sendMessageEmbeds(banEmbed).queue();
         target.ban(7, reason).queue(null, throwable -> actionLog.sendMessageEmbeds(

--- a/src/main/java/net/irisshaders/lilybot/commands/services/GitHub.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/services/GitHub.java
@@ -8,6 +8,8 @@ import net.dv8tion.jda.api.events.interaction.commands.SlashCommandEvent;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.irisshaders.lilybot.LilyBot;
+import net.irisshaders.lilybot.utils.ResponseHelper;
+
 import org.kohsuke.github.*;
 
 import java.awt.*;
@@ -62,14 +64,11 @@ public class GitHub extends SlashCommand {
             try {
                 issue = parseMessage(repo, term);
             } catch (Exception e) {
-                MessageEmbed noMatchesEmbed = new EmbedBuilder()
+                MessageEmbed noMatchesEmbed = ResponseHelper.responseEmbed(user, Color.RED)
                         .setDescription(
                                 "Invalid issue number or an invalid repository was provided." +
                                 " Please ensure the issue exists and the repository is public."
                         )
-                        .setColor(Color.RED)
-                        .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                        .setTimestamp(Instant.now())
                         .build();
                 event.replyEmbeds(noMatchesEmbed).mentionRepliedUser(false).setEphemeral(true).queue();
                 return;
@@ -215,16 +214,13 @@ public class GitHub extends SlashCommand {
             String repoName = event.getOption("repo").getAsString();
 
             if (!repoName.contains("/")) {
-                MessageEmbed incorrectSyntaxEmbed = new EmbedBuilder()
+                MessageEmbed incorrectSyntaxEmbed = ResponseHelper.responseEmbed(user, Color.RED)
                         .setDescription("""
                             Make sure your input is formatted like this:
                             Format: User/Repo or Org/Repo
                             For example: `IrisShaders/Iris`
                             """
                         )
-                        .setColor(Color.RED)
-                        .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                        .setTimestamp(Instant.now())
                         .build();
                 event.replyEmbeds(incorrectSyntaxEmbed).mentionRepliedUser(false).setEphemeral(true).queue();
                 return;
@@ -235,11 +231,8 @@ public class GitHub extends SlashCommand {
             try {
                 repo = LilyBot.INSTANCE.gitHub.getRepository(repoName);
             } catch (IOException e) {
-                MessageEmbed noMatchesEmbed = new EmbedBuilder()
+                MessageEmbed noMatchesEmbed = ResponseHelper.responseEmbed(user, Color.RED)
                         .setDescription("Invalid repository name. Make sure this repository exists!")
-                        .setColor(Color.RED)
-                        .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                        .setTimestamp(Instant.now())
                         .build();
                 event.replyEmbeds(noMatchesEmbed).mentionRepliedUser(false).setEphemeral(true).queue();
                 return;
@@ -306,11 +299,8 @@ public class GitHub extends SlashCommand {
             try {
                 ghUser = LilyBot.INSTANCE.gitHub.getUser(username);
             } catch (IOException e) {
-                MessageEmbed noMatchesEmbed = new EmbedBuilder()
+                MessageEmbed noMatchesEmbed = ResponseHelper.responseEmbed(user, Color.RED)
                         .setDescription("Invalid username. Make sure this user exists.")
-                        .setColor(Color.RED)
-                        .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                        .setTimestamp(Instant.now())
                         .build();
                 event.replyEmbeds(noMatchesEmbed).mentionRepliedUser(false).setEphemeral(true).queue();
             }

--- a/src/main/java/net/irisshaders/lilybot/utils/ResponseHelper.java
+++ b/src/main/java/net/irisshaders/lilybot/utils/ResponseHelper.java
@@ -18,18 +18,48 @@ public class ResponseHelper {
      */
     public static MessageEmbed genFailureEmbed(User user, String title, String description) {
 
-        EmbedBuilder embed = new EmbedBuilder()
-                .setTitle("Something went wrong!")
-                .setDescription("Please try again!")
-                .setColor(Color.RED)
-                .setFooter("Requested by " + user.getAsTag(), user.getEffectiveAvatarUrl())
-                .setTimestamp(Instant.now());
+        EmbedBuilder embed = responseEmbed("Something went wrong!", user, Color.RED)
+                .setDescription("Please try again!");
 
         if (title != null) embed.setTitle(title);
         if (description != null) embed.setDescription(description);
 
         return embed.build();
-
+    }
+    
+    /**
+     * Creates an {@link EmbedBuilder} and populates it with the current timestamp, the given {@link User} as the
+     * requester and the given {@link Color} as its color.
+     * 
+     * @param title The title to set the embed to, or {@code null} to set no title (prefer using {@link #responseEmbed(User, Color)} instead of null)
+     * @param requester The user to display information from in the "Requested by" section. Must not be {@code null}
+     * @param color The color to set the embed to. If it's {@code null}, the embed will have no color
+     * @return An {@link EmbedBuilder} with the given parameters
+     * 
+     * @see #responseEmbed(User, Color)
+     */
+    public static EmbedBuilder responseEmbed(String title, User requester, Color color) {
+        return responseEmbed(requester, color)
+            .setTitle(title);
+    }
+    
+    /**
+     * Creates an {@link EmbedBuilder} and populates it with the current timestamp, the given {@link User} as the
+     * requester and the given {@link Color} as its color.<p>
+     * 
+     * If you want to set a title, consider using {@link #responseEmbed(String, User, Color)} instead
+     * 
+     * @param requester The user to display information from in the "Requested by" section. Must not be {@code null}
+     * @param color The color to set the embed to. If it's {@code null}, the embed will have no color
+     * @return An {@link EmbedBuilder} with the given parameters
+     * 
+     * @see #responseEmbed(String, User, Color)
+     */
+    public static EmbedBuilder responseEmbed(User requester, Color color) {
+        return new EmbedBuilder()
+            .setTimestamp(Instant.now())
+            .setColor(color)
+            .setFooter("Requested by " + requester.getAsTag(), requester.getEffectiveAvatarUrl());
     }
 
 }


### PR DESCRIPTION
This creates a very simple method (well actually two, but the other one is the same without title):
```java
public static EmbedBuilder responseEmbed(String title, User requester, Color color) {
   	return new EmbedBuilder()
   		.setTimestamp(Instant.now())
   		.setColor(color)
   		.setFooter("Requested by " + requester.getAsTag(), requester.getEffectiveAvatarUrl())
		.setTitle(title);
}
```

And moves everything doing that to use it.

Also makes three small things:
- Reuses EmbedBuilder on Ping instead of creating a new one that's the same
- Adds user tag to kick and ban fail embeds
- Fixes description of check-points argument