### PR TITLE
Allow banning non-members and add ids to action log messages

### DIFF
--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Kick.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Kick.java
@@ -44,7 +44,7 @@ public class Kick extends SlashCommand {
         member.kick(reason).queue(unused -> {
 
             MessageEmbed kickEmbed = ResponseHelper.responseEmbed("Kicked a member", user, Color.GREEN)
-                    .addField("Kicked:", member.getUser().getAsTag(), false)
+                    .addField("Kicked:", ResponseHelper.userField(member.getUser()), false)
                     .addField("Reason:", reason, false)
                     .build();
 

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Mute.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Mute.java
@@ -129,7 +129,7 @@ public class Mute extends SlashCommand {
         Role mutedRole = LilyBot.INSTANCE.jda.getRoleById(Constants.MUTED_ROLE);
 
         MessageEmbed muteEmbed = ResponseHelper.responseEmbed("Mute", mute.requester(), Color.CYAN)
-                .addField("Muted:", mute.target().getUser().getAsMention(), false)
+                .addField("Muted:", ResponseHelper.userField(mute.target().getUser()), false)
                 .addField("Muted until:", DateHelper.formatRelative(mute.expiry()), false)
                 .addField("Reason:", mute.reason(), false)
                 .build();

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/MuteList.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/MuteList.java
@@ -45,7 +45,7 @@ public class MuteList extends SlashCommand {
             EmbedBuilder muteListEmbedBuilder = ResponseHelper.responseEmbed("Muted Users", user, Color.CYAN)
                     .setDescription("These are the muted members:");
             for (MuteEntry mute: mutedMembers) {
-                muteListEmbedBuilder.addField("User:", mute.target().getUser().getAsTag(), false);
+                muteListEmbedBuilder.addField("User:", ResponseHelper.userField(mute.target().getUser()), false);
                 muteListEmbedBuilder.addField("Muted by:", mute.requester().getAsTag(), true);
                 muteListEmbedBuilder.addField("Expires:", DateHelper.formatDateAndTime(mute.expiry()), true);
                 muteListEmbedBuilder.addField("Reason:", mute.reason(), true);

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Report.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Report.java
@@ -131,7 +131,7 @@ public class Report extends Command implements EventListener {
                 .setTitle(title)
                 .setDescription("A message was reported in " + channel)
                 .addField("Message Content:", contentDisplay, false)
-                .addField("Message Author:", author.getAsTag(), false)
+                .addField("Message Author:", ResponseHelper.userField(author), false)
                 .setColor(Color.CYAN)
                 .setFooter("Message reported by " + user.getAsTag(), user.getEffectiveAvatarUrl())
                 .setTimestamp(Instant.now())

--- a/src/main/java/net/irisshaders/lilybot/commands/moderation/Unban.java
+++ b/src/main/java/net/irisshaders/lilybot/commands/moderation/Unban.java
@@ -38,18 +38,18 @@ public class Unban extends SlashCommand {
         TextChannel actionLog = event.getGuild().getTextChannelById(Constants.ACTION_LOG);
         Guild guild = event.getGuild();
         User userById = event.getOption("id").getAsUser();
-        User user = event.getUser();
+        User requester = event.getUser();
 
         guild.unban(userById).queue(unused -> {
 
-            MessageEmbed unbanEmbed = ResponseHelper.responseEmbed("Unbanned a member", user, Color.CYAN)
-                    .addField("Unbanned:", userById.getAsTag(), false)
+            MessageEmbed unbanEmbed = ResponseHelper.responseEmbed("Unbanned a member", requester, Color.CYAN)
+                    .addField("Unbanned:", ResponseHelper.userField(userById), false)
                     .build();
 
             event.replyEmbeds(unbanEmbed).mentionRepliedUser(false).setEphemeral(true).queue();
             actionLog.sendMessageEmbeds(unbanEmbed).queue();
 
-        }, throwable -> event.replyEmbeds(ResponseHelper.genFailureEmbed(user, "Failed to unban.", null))
+        }, throwable -> event.replyEmbeds(ResponseHelper.genFailureEmbed(requester, "Failed to unban.", null))
                 .mentionRepliedUser(false).setEphemeral(true).queue()
         );
 

--- a/src/main/java/net/irisshaders/lilybot/utils/ResponseHelper.java
+++ b/src/main/java/net/irisshaders/lilybot/utils/ResponseHelper.java
@@ -61,5 +61,17 @@ public class ResponseHelper {
             .setColor(color)
             .setFooter("Requested by " + requester.getAsTag(), requester.getEffectiveAvatarUrl());
     }
+    
+    /**
+     * Creates a {@link String} containing the user as a mention, and their user tag {@code @user (user#1234)},
+     * to be used in moderation embeds where linking with the user id and their possibly changed name is desirable,
+     * but knowing the tag at the time of action is also important.
+     * 
+     * @param user The user to produce the string from
+     * @return The {@link String} being the user's mention followed by the user's tag (in parenthesis)
+     */
+    public static String userField(User user) {
+        return user.getAsMention() + " (" + user.getAsTag() + ")";
+    }
 
 }


### PR DESCRIPTION
With adding ids to action log messages I mean adding a mention to them (you can get the id from that by right clicking > copy id). I kept the tag too, since it can be useful to have the non-mutable tag at the moment of the action happening (for example, if a user was banned because of their tag) or if discord (mobile) decides to convert the mention to `@invalid-user`.

Examples (first not in server, second just the id thing being applied to other mod embeds):
![imagen](https://user-images.githubusercontent.com/17107132/146674222-18773331-103b-4977-b957-a85bf002639e.png) ![imagen](https://user-images.githubusercontent.com/17107132/146674007-6a5992fa-e8a5-44b1-a26f-3b70c0626aa2.png)

Also changed some variable names because they could easily be confused between target and requester.

Didn't change what's sent in member join/leave embeds, however if wanted it should be really easy to do those given this comes from a convenience method added in `ResponseHelper` that creates the string with the mention and the tag from a `User`.