### PR TITLE
Add support for detecting Not Enough Crashes in log files, add /nec slash command

### DIFF
--- a/lily.properties
+++ b/lily.properties
@@ -4,11 +4,15 @@
 # You may make your own config file elsewhere if you'd rather make your own.
 status = Iris
 
-commands = shader-config crash-report eta indium logs rule shader-editing sodium starline updatedrivers optifine rtx jarfix snapshots
+commands = shader-config crash-report eta indium logs rule shader-editing sodium starline updatedrivers optifine rtx jarfix snapshots nec
 
 shader-config.help = Informs the user of Shader Config issues.
 shader-config.title = You can't currently edit shader settings.
 shader-config.desc = The shader configuration menu is currently in development, and is being privately tested among developers. The current iteration has many critical issues that we are not comfortable with releasing.\n\n\u2022 Progress updates can be found in <#774354933436645478>\n\u2022 Test builds, once available, can be found in <#883067831485366304>\n\u2022 Full releases will be announced in <#817181278931517453>\n\nPlease do not ask for an ETA on this or any other feature.
+
+nec.help = Informs the user of issues with Not Enough Crashes.
+nec.title = Remove Not Enough Crashes from your mods folder.
+nec.desc = Not Enough Crashes (NEC) is well know to cause issues and often makes the debugging process more difficult. A good alternative is Crafty Crashes (https://github.com/Chocohead/Crafty-Crashes/releases/tag/v1.0)\nIf you had previously sent a log or crash report please remove NEC, recreate the issue, and resend the relevant files if the issue persists. 
 
 crash-report.help = Informs the user of how to get a crash report.
 crash-report.title = How to get crash reports:

--- a/src/main/java/net/irisshaders/lilybot/events/AttachmentHandler.java
+++ b/src/main/java/net/irisshaders/lilybot/events/AttachmentHandler.java
@@ -53,7 +53,7 @@ public class AttachmentHandler extends ListenerAdapter {
                     int indexOfToken = builder.indexOf(tokenKey);
                     if (indexOfToken != -1) {
                         int endOfToken = builder.indexOf(" ", indexOfToken + tokenKey.length() + 1);
-                        builder.replace(indexOfToken + tokenKey.length() + 1, endOfToken, "**removed acess token**");
+                        builder.replace(indexOfToken + tokenKey.length() + 1, endOfToken, "**removed access token**");
                     }
                     final String necText = "at Not Enough Crashes";
                     int indexOfnecText = builder.indexOf(necText);

--- a/src/main/java/net/irisshaders/lilybot/events/AttachmentHandler.java
+++ b/src/main/java/net/irisshaders/lilybot/events/AttachmentHandler.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.hooks.ListenerAdapter;
 import net.dv8tion.jda.api.interactions.components.Button;
 
 import javax.net.ssl.HttpsURLConnection;
+import java.awt.Color;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -54,6 +55,18 @@ public class AttachmentHandler extends ListenerAdapter {
                         int endOfToken = builder.indexOf(" ", indexOfToken + tokenKey.length() + 1);
                         builder.replace(indexOfToken + tokenKey.length() + 1, endOfToken, "**removed acess token**");
                     }
+                    final String necText = "at Not Enough Crashes";
+                    int indexOfnecText = builder.indexOf(necText);
+                    if (indexOfnecText != -1) {
+                        uploadMessage.join().editMessageEmbeds(fileEmbed(author)
+                                        .setTitle("Not Enough Crashes detected in logs")
+                                        .addField("Not Enough Crashes", "Not Enough Crashes (NEC) is well know to cause issues and often makes the debugging process more difficult. Please remove NEC, recreate the issue, and resend the relevant files (ie. log or crash report) if the issue persists.", false)
+                                        .setColor(Color.RED)
+                                        .build())
+                                .queue();
+                        return;
+                    }
+
                     try {
                         uploadMessage.join().editMessageEmbeds(fileEmbed(author).setTitle("`" + name + "` uploaded to Hastebin").build()).setActionRow(
                                 Button.link(post(builder.toString()), "Click here to view")


### PR DESCRIPTION
Uses tempest's wording for both the slash command and the user feedback embed when NEC is detected
Also fixes spelling mistake in AttachmentHandler.java