### PR TITLE
De-duplicate some of the database checking code

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/config/Config.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/config/Config.kt
@@ -14,7 +14,7 @@ import dev.kord.common.entity.Permission
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
 import net.irisshaders.lilybot.utils.ConfigData
 import net.irisshaders.lilybot.utils.DatabaseHelper
-import net.irisshaders.lilybot.utils.ResponseHelper
+import net.irisshaders.lilybot.utils.responseEmbedInChannel
 
 class Config : Extension() {
 
@@ -62,7 +62,7 @@ class Config : Extension() {
 
 					// Log the config being set in the action log
 					val actionLogChannel = guild?.getChannel(arguments.modActionLog.id) as GuildMessageChannelBehavior
-					ResponseHelper.responseEmbedInChannel(
+					responseEmbedInChannel(
 						actionLogChannel,
 						"Configuration set!",
 						"An administrator has set a config for this guild!",
@@ -89,7 +89,7 @@ class Config : Extension() {
 						// Log the config being cleared to the action log
 						val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
 						val actionLogChannel = guild?.getChannel(actionLogId!!) as GuildMessageChannelBehavior
-						ResponseHelper.responseEmbedInChannel(
+						responseEmbedInChannel(
 							actionLogChannel,
 							"Configuration cleared!",
 							"An administrator has cleared the configuration for this guild!",

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/JoinLeaveEvent.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/JoinLeaveEvent.kt
@@ -22,7 +22,6 @@ import kotlin.time.ExperimentalTime
 class JoinLeaveEvent : Extension() {
 	override val name = "join-leave-event"
 
-	@Suppress("DuplicatedCode")
 	override suspend fun setup() {
 		event<MemberJoinEvent> {
 			action {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageEvents.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageEvents.kt
@@ -25,7 +25,7 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.util.toByteArray
 import kotlinx.datetime.Clock
 import net.irisshaders.lilybot.utils.DatabaseHelper
-import net.irisshaders.lilybot.utils.ResponseHelper
+import net.irisshaders.lilybot.utils.responseEmbedInChannel
 import java.io.ByteArrayInputStream
 import java.util.zip.GZIPInputStream
 import kotlin.time.ExperimentalTime
@@ -128,7 +128,7 @@ class MessageEvents : Extension() {
 						val necText = "at Not Enough Crashes"
 						val indexOfNECText = builder.indexOf(necText)
 						if (indexOfNECText != -1) {
-							ResponseHelper.responseEmbedInChannel(
+							responseEmbedInChannel(
 								eventMessage.channel,
 								"Not Enough Crashes detected in logs",
 								"Not Enough Crashes (NEC) is well know to cause issues and often " +
@@ -142,7 +142,7 @@ class MessageEvents : Extension() {
 							// Ask the user if they're ok with uploading their log to a paste site
 							var confirmationMessage: Message? = null
 
-							confirmationMessage = ResponseHelper.responseEmbedInChannel(
+							confirmationMessage = responseEmbedInChannel(
 								eventMessage.channel,
 								"Do you want to upload this file to Hastebin?",
 								"Hastebin is a website that allows users to share plain text through " +

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Moderation.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Moderation.kt
@@ -6,6 +6,7 @@ import com.kotlindiscord.kord.extensions.DISCORD_BLACK
 import com.kotlindiscord.kord.extensions.DISCORD_GREEN
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.impl.coalescingDefaultingDuration
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingInt
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingString
@@ -26,7 +27,6 @@ import dev.kord.core.behavior.edit
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.core.supplier.EntitySupplyStrategy
 import dev.kord.rest.request.KtorRequestException
-import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.toList
 import kotlinx.datetime.Clock
@@ -36,6 +36,7 @@ import kotlinx.datetime.plus
 import mu.KotlinLogging
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.ResponseHelper
+import net.irisshaders.lilybot.utils.getFromConfig
 import java.lang.Integer.min
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
@@ -60,13 +61,7 @@ class Moderation : Extension() {
 
 			action {
 				// Try to get the action log from the config. If a config is not set, inform the user and return@action
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				if (actionLogId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-					}
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val messageAmount = arguments.messages
@@ -76,7 +71,7 @@ class Moderation : Extension() {
 
 				val messages = channel.withStrategy(EntitySupplyStrategy.rest).getMessagesBefore(
 					Snowflake.max, min(messageAmount, 100)
-				).filterNotNull().map { it.id }.toList()
+				).map { it.id }.toList()
 
 				textChannel.bulkDelete(messages)
 
@@ -109,14 +104,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id, "moderatorsPing")
-				if (actionLogId == null || moderatorRoleId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-					}
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -213,13 +202,7 @@ class Moderation : Extension() {
 
 			action {
 				// Try to get the action log from the config. If a config is not set, inform the user and return@action
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				if (actionLogId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-					}
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -260,14 +243,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id, "moderatorsPing")
-				if (actionLogId == null || moderatorRoleId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-					}
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -367,14 +344,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id, "moderatorsPing")
-				if (actionLogId == null || moderatorRoleId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-					}
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -457,14 +428,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id, "moderatorsPing")
-				if (actionLogId == null || moderatorRoleId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-					}
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
 
 				val userArg = arguments.userArgument
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
@@ -634,14 +599,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id, "moderatorsPing")
-				if (actionLogId == null || moderatorRoleId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-					}
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -786,7 +745,6 @@ class Moderation : Extension() {
 			}
 		}
 	}
-
 
 	inner class ClearArgs : Arguments() {
 		val messages by int {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Moderation.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Moderation.kt
@@ -60,7 +60,6 @@ class Moderation : Extension() {
 			check { hasPermission(Permission.ManageMessages) }
 
 			action {
-				// Try to get the action log from the config. If a config is not set, inform the user and return@action
 				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
@@ -101,8 +100,6 @@ class Moderation : Extension() {
 			check { hasPermission(Permission.BanMembers) }
 
 			action {
-				// Try to get the action log and moderator ping role from the config.
-				// If a config is not set, inform the user and return@action
 				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
@@ -200,7 +197,6 @@ class Moderation : Extension() {
 			check { hasPermission(Permission.BanMembers) }
 
 			action {
-				// Try to get the action log from the config. If a config is not set, inform the user and return@action
 				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
@@ -240,8 +236,6 @@ class Moderation : Extension() {
 			check { hasPermission(Permission.BanMembers) }
 
 			action {
-				// Try to get the action log and moderator ping role from the config.
-				// If a config is not set, inform the user and return@action
 				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
@@ -341,8 +335,6 @@ class Moderation : Extension() {
 			check { hasPermission(Permission.KickMembers) }
 
 			action {
-				// Try to get the action log and moderator ping role from the config.
-				// If a config is not set, inform the user and return@action
 				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
@@ -425,8 +417,6 @@ class Moderation : Extension() {
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {
-				// Try to get the action log and moderator ping role from the config.
-				// If a config is not set, inform the user and return@action
 				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
@@ -596,8 +586,6 @@ class Moderation : Extension() {
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {
-				// Try to get the action log and moderator ping role from the config.
-				// If a config is not set, inform the user and return@action
 				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
@@ -705,7 +693,6 @@ class Moderation : Extension() {
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {
-				// Try to get the action log from the config. If a config is not set, inform the user and return@action
 				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
 				if (actionLogId == null) {
 					respond {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Moderation.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Moderation.kt
@@ -6,7 +6,6 @@ import com.kotlindiscord.kord.extensions.DISCORD_BLACK
 import com.kotlindiscord.kord.extensions.DISCORD_GREEN
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.commands.Arguments
-import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
 import com.kotlindiscord.kord.extensions.commands.converters.impl.coalescingDefaultingDuration
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingInt
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingString
@@ -35,8 +34,9 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import mu.KotlinLogging
 import net.irisshaders.lilybot.utils.DatabaseHelper
-import net.irisshaders.lilybot.utils.ResponseHelper
-import net.irisshaders.lilybot.utils.getFromConfig
+import net.irisshaders.lilybot.utils.getFromConfigPrivateResponse
+import net.irisshaders.lilybot.utils.responseEmbedInChannel
+import net.irisshaders.lilybot.utils.userDMEmbed
 import java.lang.Integer.min
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
@@ -61,7 +61,7 @@ class Moderation : Extension() {
 
 			action {
 				// Try to get the action log from the config. If a config is not set, inform the user and return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val messageAmount = arguments.messages
@@ -70,8 +70,7 @@ class Moderation : Extension() {
 				// Get the specified amount of messages into an array list of Snowflakes and delete them
 
 				val messages = channel.withStrategy(EntitySupplyStrategy.rest).getMessagesBefore(
-					Snowflake.max, min(messageAmount, 100)
-				).map { it.id }.toList()
+					Snowflake.max, min(messageAmount, 100)).map { it.id }.toList()
 
 				textChannel.bulkDelete(messages)
 
@@ -79,7 +78,7 @@ class Moderation : Extension() {
 					content = "Messages cleared"
 				}
 
-				ResponseHelper.responseEmbedInChannel(
+				responseEmbedInChannel(
 					actionLog,
 					"$messageAmount messages have been cleared.",
 					"Action occurred in ${textChannel.mention}",
@@ -104,8 +103,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
-				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -128,7 +127,7 @@ class Moderation : Extension() {
 				}
 
 				// DM the user before the ban task is run, to avoid error, null if fails
-				val dm = ResponseHelper.userDMEmbed(
+				val dm = userDMEmbed(
 					userArg,
 					"You have been banned from ${guild?.fetchGuild()?.name}",
 					"**Reason:**\n${arguments.reason}",
@@ -202,7 +201,7 @@ class Moderation : Extension() {
 
 			action {
 				// Try to get the action log from the config. If a config is not set, inform the user and return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -219,7 +218,7 @@ class Moderation : Extension() {
 					content = "Unbanned user"
 				}
 
-				ResponseHelper.responseEmbedInChannel(
+				responseEmbedInChannel(
 					actionLog,
 					"Unbanned a user",
 					"${userArg.mention} has been unbanned!\n${userArg.id} (${userArg.tag})",
@@ -243,8 +242,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
-				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -271,7 +270,7 @@ class Moderation : Extension() {
 				}
 
 				// DM the user before the ban task is run
-				val dm = ResponseHelper.userDMEmbed(
+				val dm = userDMEmbed(
 					userArg,
 					"You have been soft-banned from ${guild?.fetchGuild()?.name}",
 					"**Reason:**\n${arguments.reason}\n\n" +
@@ -344,8 +343,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
-				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -370,7 +369,7 @@ class Moderation : Extension() {
 				}
 
 				// DM the user about it before the kick
-				val dm = ResponseHelper.userDMEmbed(
+				val dm = userDMEmbed(
 					userArg,
 					"You have been kicked from ${guild?.fetchGuild()?.name}",
 					"**Reason:**\n${arguments.reason}",
@@ -428,8 +427,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
-				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
 				val userArg = arguments.userArgument
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
@@ -461,7 +460,7 @@ class Moderation : Extension() {
 				val databasePoints = DatabaseHelper.selectInWarn(userArg.id, guild!!.id)
 
 				// DM the user about the warning
-				val dm = ResponseHelper.userDMEmbed(
+				val dm = userDMEmbed(
 					userArg,
 					"You have been warned in ${guild?.fetchGuild()?.name}",
 					"You were given ${arguments.warnPoints} points\n" +
@@ -471,7 +470,7 @@ class Moderation : Extension() {
 
 				// Check the points amount, before running sanctions
 				if (databasePoints in (75..124)) {
-					ResponseHelper.userDMEmbed(
+					userDMEmbed(
 						userArg,
 						"You have been timed-out in ${guild!!.fetchGuild().name}",
 						"You have accumulated too many warn points, and have hence been given a " +
@@ -483,7 +482,7 @@ class Moderation : Extension() {
 						timeoutUntil = Clock.System.now().plus(Duration.parse("PT3H"))
 					}
 
-					ResponseHelper.responseEmbedInChannel(
+					responseEmbedInChannel(
 						actionLog,
 						"Timeout",
 						"${userArg.mention} has been timed-out for 3 hours due to point " +
@@ -492,7 +491,7 @@ class Moderation : Extension() {
 						user.asUser()
 					)
 				} else if (databasePoints in (125..199)) {
-					ResponseHelper.userDMEmbed(
+					userDMEmbed(
 						userArg,
 						"You have been timed-out in ${guild!!.fetchGuild().name}",
 						"You have accumulated too many warn points, and have hence been given " +
@@ -504,7 +503,7 @@ class Moderation : Extension() {
 						timeoutUntil = Clock.System.now().plus(Duration.parse("PT12H"))
 					}
 
-					ResponseHelper.responseEmbedInChannel(
+					responseEmbedInChannel(
 						actionLog,
 						"Timeout",
 						"${userArg.mention} has been timed-out for 12 hours due to point " +
@@ -515,7 +514,7 @@ class Moderation : Extension() {
 				} else if (databasePoints >= 200) {
 					guild?.getMember(userArg.id)
 						?.edit { timeoutUntil = null } // Remove timeout in case they were timed out when banned
-					ResponseHelper.userDMEmbed(
+					userDMEmbed(
 						userArg,
 						"You have been banned from ${guild!!.fetchGuild().name}",
 						"You have accumulated too many warn points, and have hence been banned",
@@ -527,7 +526,7 @@ class Moderation : Extension() {
 						this.deleteMessagesDays = 0
 					})
 
-					ResponseHelper.responseEmbedInChannel(
+					responseEmbedInChannel(
 						actionLog,
 						"User Banned!",
 						"${userArg.mention} has been banned due to point accumulation\n${userArg.id} (${userArg.tag})",
@@ -599,8 +598,8 @@ class Moderation : Extension() {
 			action {
 				// Try to get the action log and moderator ping role from the config.
 				// If a config is not set, inform the user and return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
-				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfigPrivateResponse("moderatorsPing") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
@@ -640,7 +639,7 @@ class Moderation : Extension() {
 
 				// Send the DM after the timeout task, in case Lily doesn't have required permissions
 				// DM the user about it
-				val dm = ResponseHelper.userDMEmbed(
+				val dm = userDMEmbed(
 					userArg,
 					"You have been timed out in ${guild?.fetchGuild()?.name}",
 					"**Duration:**\n${

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Report.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Report.kt
@@ -30,9 +30,8 @@ import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.rest.request.KtorRequestException
 import dev.kord.rest.request.RestRequestException
 import kotlinx.datetime.Clock
-import net.irisshaders.lilybot.utils.DatabaseHelper
-import net.irisshaders.lilybot.utils.ResponseHelper
-import net.irisshaders.lilybot.utils.getFromConfig
+import net.irisshaders.lilybot.utils.getFromConfigPublicResponse
+import net.irisshaders.lilybot.utils.userDMEmbed
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -51,9 +50,9 @@ class Report : Extension() {
 
 			action {
 				// Try to get the action log, message log and moderators from config
-				val messageLogId = getFromConfig("messageLogs") ?: return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
-				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
+				val messageLogId = getFromConfigPublicResponse("messageLogs") ?: return@action
+				val actionLogId = getFromConfigPublicResponse("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfigPublicResponse("moderatorsPing") ?: return@action
 
 				val messageLog = guild?.getChannel(messageLogId) as GuildMessageChannelBehavior
 				try {
@@ -86,9 +85,9 @@ class Report : Extension() {
 
 			action {
 				// Try to get the action log, message log and moderators from config
-				val messageLogId = getFromConfig("messageLogs") ?: return@action
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
-				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
+				val messageLogId = getFromConfigPublicResponse("messageLogs") ?: return@action
+				val actionLogId = getFromConfigPublicResponse("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfigPublicResponse("moderatorsPing") ?: return@action
 
 				val messageLog = guild?.getChannel(messageLogId) as GuildMessageChannelBehavior
 
@@ -222,7 +221,7 @@ class Report : Extension() {
 								respond {
 									content = "Timed out user for 10 minutes"
 								}
-								ResponseHelper.userDMEmbed(
+								userDMEmbed(
 									messageAuthor!!.asUser(),
 									"You have been timed out in ${guild?.fetchGuild()?.name}",
 									"**Duration:**\n10 minutes\n**Reason:**\nTimed-out via report",
@@ -237,7 +236,7 @@ class Report : Extension() {
 								respond {
 									content = "Timed out user for 20 minutes"
 								}
-								ResponseHelper.userDMEmbed(
+								userDMEmbed(
 									messageAuthor!!.asUser(),
 									"You have been timed out in ${guild?.fetchGuild()?.name}",
 									"**Duration:**\n20 minutes\n**Reason:**\nTimed-out via report",
@@ -252,7 +251,7 @@ class Report : Extension() {
 								respond {
 									content = "Timed out user for 30 minutes"
 								}
-								ResponseHelper.userDMEmbed(
+								userDMEmbed(
 									messageAuthor!!.asUser(),
 									"You have been timed out in ${guild?.fetchGuild()?.name}",
 									"**Duration:**\n30 minutes\n**Reason:**\nTimed-out via report",
@@ -261,7 +260,7 @@ class Report : Extension() {
 								quickTimeoutEmbed(actionLog, messageAuthor.asUser(), 30)
 							}
 							"kick-user" -> {
-								ResponseHelper.userDMEmbed(
+								userDMEmbed(
 									messageAuthor!!.asUser(),
 									"You have been kicked from ${guild?.fetchGuild()?.name}",
 									"**Reason:**\nKicked via report",
@@ -271,7 +270,7 @@ class Report : Extension() {
 								quickLogEmbed("Kicked a User", actionLog, messageAuthor.asUser())
 							}
 							"soft-ban-user" -> {
-								ResponseHelper.userDMEmbed(
+								userDMEmbed(
 									messageAuthor!!.asUser(),
 									"You have been soft-banned from ${guild?.fetchGuild()?.name}",
 									"**Reason:**\nSoft-banned via report\n\n" +
@@ -286,7 +285,7 @@ class Report : Extension() {
 								quickLogEmbed("Soft-Banned a User", actionLog, messageAuthor.asUser())
 							}
 							"ban-user" -> {
-								ResponseHelper.userDMEmbed(
+								userDMEmbed(
 									messageAuthor!!.asUser(),
 									"You have been banned from ${guild?.fetchGuild()?.name}",
 									"**Reason:**\nBanned via report",

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Report.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Report.kt
@@ -32,6 +32,7 @@ import dev.kord.rest.request.RestRequestException
 import kotlinx.datetime.Clock
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.ResponseHelper
+import net.irisshaders.lilybot.utils.getFromConfig
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 
@@ -50,16 +51,9 @@ class Report : Extension() {
 
 			action {
 				// Try to get the action log, message log and moderators from config
-				val messageLogId = DatabaseHelper.selectInConfig(guild!!.id, "messageLogs")
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id, "moderatorsPing")
-
-				if (messageLogId == null || actionLogId == null || moderatorRoleId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Please inform a member of staff!"
-					}
-					return@action
-				}
+				val messageLogId = getFromConfig("messageLogs") ?: return@action
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
 
 				val messageLog = guild?.getChannel(messageLogId) as GuildMessageChannelBehavior
 				try {
@@ -92,16 +86,9 @@ class Report : Extension() {
 
 			action {
 				// Try to get the action log, message log and moderators from config
-				val messageLogId = DatabaseHelper.selectInConfig(guild!!.id, "messageLogs")
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-				val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id, "moderatorsPing")
-
-				if (messageLogId == null || actionLogId == null || moderatorRoleId == null) {
-					respond {
-						content = "**Error:** Unable to access config for this guild! Please inform a member of staff!"
-					}
-					return@action
-				}
+				val messageLogId = getFromConfig("messageLogs") ?: return@action
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val moderatorRoleId = getFromConfig("moderatorsPing") ?: return@action
 
 				val messageLog = guild?.getChannel(messageLogId) as GuildMessageChannelBehavior
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Report.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Report.kt
@@ -49,7 +49,6 @@ class Report : Extension() {
 			locking = true // To prevent the command from being run more than once concurrently
 
 			action {
-				// Try to get the action log, message log and moderators from config
 				val messageLogId = getFromConfigPublicResponse("messageLogs") ?: return@action
 				val actionLogId = getFromConfigPublicResponse("modActionLog") ?: return@action
 				val moderatorRoleId = getFromConfigPublicResponse("moderatorsPing") ?: return@action
@@ -84,7 +83,6 @@ class Report : Extension() {
 			locking = true
 
 			action {
-				// Try to get the action log, message log and moderators from config
 				val messageLogId = getFromConfigPublicResponse("messageLogs") ?: return@action
 				val actionLogId = getFromConfigPublicResponse("modActionLog") ?: return@action
 				val moderatorRoleId = getFromConfigPublicResponse("moderatorsPing") ?: return@action

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RoleMenu.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RoleMenu.kt
@@ -136,25 +136,17 @@ class RoleMenu : Extension() {
 
 				// this is  a very dirty fix, so it doesn't conflict with log uploading
 				val roleId: Snowflake? = try {
-					DatabaseHelper.selectInComponents(
-						interaction.componentId,
-						"roleId"
-					) as Snowflake?
+					DatabaseHelper.selectInComponents(interaction.componentId, "roleId") as Snowflake?
 				} catch (e: NullPointerException) {
 					return@action
 				}
 				val addOrRemove: String? = try {
-					DatabaseHelper.selectInComponents(
-						interaction.componentId,
-						"addOrRemove"
-					) as String?
+					DatabaseHelper.selectInComponents(interaction.componentId, "addOrRemove") as String?
 				} catch (e: NullPointerException) {
 					return@action
 				}
 
-				if (roleId == null || addOrRemove == null) {
-					return@action
-				}
+				if (roleId == null || addOrRemove == null) return@action
 
 				val role = guild.getRole(roleId)
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
@@ -20,6 +20,8 @@ import dev.kord.core.behavior.channel.threads.edit
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import kotlinx.coroutines.flow.toList
 import net.irisshaders.lilybot.utils.DatabaseHelper
+import net.irisshaders.lilybot.utils.getFromConfig
+import net.irisshaders.lilybot.utils.getFromConfigPublicResponse
 import kotlin.time.ExperimentalTime
 
 class ThreadControl : Extension() {
@@ -50,14 +52,7 @@ class ThreadControl : Extension() {
 
 					// Try to get the moderator ping role from the config.
 					// If a config is not set, inform the user and return@action
-					val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id,
-						"moderatorsPing")
-					if (moderatorRoleId == null) {
-						respond {
-							content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-						}
-						return@action
-					}
+					val moderatorRoleId = getFromConfigPublicResponse("moderatorsPing") ?: return@action
 
 					if (moderatorRoleId in roles) {
 						channel.edit {
@@ -107,14 +102,7 @@ class ThreadControl : Extension() {
 
 					// Try to get the moderator ping role from the config.
 					// If a config is not set, inform the user and return@action
-					val moderatorRoleId = DatabaseHelper.selectInConfig(guild!!.id,
-						"moderatorsPing")
-					if (moderatorRoleId == null) {
-						respond {
-							content = "**Error:** Unable to access config for this guild! Is your configuration set?"
-						}
-						return@action
-					}
+					val moderatorRoleId = getFromConfigPublicResponse("moderatorsPing") ?: return@action
 
 					if (moderatorRoleId in roles) {
 						channel.edit {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
@@ -19,8 +19,10 @@ import dev.kord.core.behavior.channel.threads.edit
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import kotlinx.coroutines.flow.toList
 import net.irisshaders.lilybot.utils.getFromConfigPublicResponse
+import net.irisshaders.lilybot.utils.isThread
 import kotlin.time.ExperimentalTime
 
+@Suppress("DuplicatedCode")
 class ThreadControl : Extension() {
 
 	override val name = "thread-control"
@@ -34,14 +36,8 @@ class ThreadControl : Extension() {
 				name = "rename"
 				description = "Rename a thread!"
 
-				@Suppress("DuplicatedCode")
 				action {
-					if (channel.asChannel() !is ThreadChannel) {
-						edit {
-							content = "This isn't a thread :person_facepalming:"
-						}
-						return@action
-					}
+					if (!isThread()) return@action
 
 					val channel = channel.asChannel() as ThreadChannel
 					val member = user.asMember(guild!!.id)
@@ -86,12 +82,7 @@ class ThreadControl : Extension() {
 
 				@Suppress("DuplicatedCode")
 				action {
-					if (channel.asChannel() !is ThreadChannel) {
-						edit {
-							content = "This isn't a thread :person_facepalming:"
-						}
-						return@action
-					}
+					if (!isThread()) return@action
 
 					val channel = channel.asChannel() as ThreadChannel
 					val member = user.asMember(guild!!.id)

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
@@ -36,7 +36,7 @@ class ThreadControl : Extension() {
 				name = "rename"
 				description = "Rename a thread!"
 
-				check { failIf { isInThread() != pass() } }
+				check { isInThread() }
 
 				action {
 
@@ -80,7 +80,7 @@ class ThreadControl : Extension() {
 				name = "archive"
 				description = "Archive this thread"
 
-				check { failIf { isInThread() != pass() } }
+				check { isInThread() }
 
 				action {
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
@@ -8,6 +8,7 @@
 
 package net.irisshaders.lilybot.extensions.util
 
+import com.kotlindiscord.kord.extensions.checks.isInThread
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.ephemeralSubCommand
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingBoolean
@@ -19,7 +20,6 @@ import dev.kord.core.behavior.channel.threads.edit
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import kotlinx.coroutines.flow.toList
 import net.irisshaders.lilybot.utils.getFromConfigPublicResponse
-import net.irisshaders.lilybot.utils.isThread
 import kotlin.time.ExperimentalTime
 
 @Suppress("DuplicatedCode")
@@ -36,15 +36,15 @@ class ThreadControl : Extension() {
 				name = "rename"
 				description = "Rename a thread!"
 
+				check { failIf { isInThread() != pass() } }
+
 				action {
-					if (!isThread()) return@action
+
 
 					val channel = channel.asChannel() as ThreadChannel
 					val member = user.asMember(guild!!.id)
 					val roles = member.roles.toList().map { it.id }
 
-					// Try to get the moderator ping role from the config.
-					// If a config is not set, inform the user and return@action
 					val moderatorRoleId = getFromConfigPublicResponse("moderatorsPing") ?: return@action
 
 					if (moderatorRoleId in roles) {
@@ -80,16 +80,14 @@ class ThreadControl : Extension() {
 				name = "archive"
 				description = "Archive this thread"
 
-				@Suppress("DuplicatedCode")
+				check { failIf { isInThread() != pass() } }
+
 				action {
-					if (!isThread()) return@action
 
 					val channel = channel.asChannel() as ThreadChannel
 					val member = user.asMember(guild!!.id)
 					val roles = member.roles.toList().map { it.id }
 
-					// Try to get the moderator ping role from the config.
-					// If a config is not set, inform the user and return@action
 					val moderatorRoleId = getFromConfigPublicResponse("moderatorsPing") ?: return@action
 
 					if (moderatorRoleId in roles) {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
@@ -15,12 +15,9 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.edit
-import com.kotlindiscord.kord.extensions.types.respond
 import dev.kord.core.behavior.channel.threads.edit
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import kotlinx.coroutines.flow.toList
-import net.irisshaders.lilybot.utils.DatabaseHelper
-import net.irisshaders.lilybot.utils.getFromConfig
 import net.irisshaders.lilybot.utils.getFromConfigPublicResponse
 import kotlin.time.ExperimentalTime
 
@@ -153,6 +150,7 @@ class ThreadControl : Extension() {
 			description = "The new name to give to the thread"
 		}
 	}
+
 	inner class ThreadArchiveArgs : Arguments() {
 		val lock by defaultingBoolean {
 			name = "lock"

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadInviter.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadInviter.kt
@@ -44,11 +44,8 @@ class ThreadInviter : Extension() {
 			// Don't try to create if the message is a slash command
 			check { failIf { event.message.type == MessageType.ChatInputCommand } }
 			// Don't try and run this if the thread is manually created
-			check {
-				failIf {
-					event.message.type == MessageType.ThreadCreated
-							|| event.message.type == MessageType.ThreadStarterMessage
-				}
+			check { failIf { event.message.type == MessageType.ThreadCreated
+					|| event.message.type == MessageType.ThreadStarterMessage }
 			}
 			// Don't try and create if Lily or another bot sent the message
 			check { failIf { event.message.author?.id == kord.selfId || event.message.author?.isBot == true } }

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Utilities.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Utilities.kt
@@ -26,9 +26,9 @@ import dev.kord.rest.request.KtorRequestException
 import kotlinx.datetime.Clock
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.ONLINE_STATUS_CHANNEL
-import net.irisshaders.lilybot.utils.ResponseHelper
 import net.irisshaders.lilybot.utils.TEST_GUILD_ID
-import net.irisshaders.lilybot.utils.getFromConfig
+import net.irisshaders.lilybot.utils.getFromConfigPrivateResponse
+import net.irisshaders.lilybot.utils.responseEmbedInChannel
 import kotlin.time.ExperimentalTime
 
 @Suppress("DuplicatedCode")
@@ -42,8 +42,10 @@ class Utilities : Extension() {
 		 * Online notification
 		 * @author IMS212
 		 */
-		ResponseHelper.responseEmbedInChannel(onlineLog, "Lily is now online!", null,
-			DISCORD_GREEN, null)
+		responseEmbedInChannel(
+			onlineLog, "Lily is now online!", null,
+			DISCORD_GREEN, null
+		)
 
 		/**
 		 * Ping Command
@@ -85,10 +87,10 @@ class Utilities : Extension() {
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
-				val targetChannel: MessageChannelBehavior = if (arguments.targetChannel == null) {
+				val targetChannel = if (arguments.targetChannel == null) {
 					channel
 				} else {
 					guild?.getChannel(arguments.targetChannel!!.id) as MessageChannelBehavior
@@ -106,14 +108,14 @@ class Utilities : Extension() {
 							content = arguments.messageArgument
 						}
 					}
-				} catch (e:KtorRequestException) {
+				} catch (e: KtorRequestException) {
 					respond { content = "Lily does not have permission to send messages in this channel." }
 					return@action
 				}
 
 				respond { content = "Message sent." }
 
-				ResponseHelper.responseEmbedInChannel(
+				responseEmbedInChannel(
 					actionLog,
 					"Message Sent",
 					"/say has been used to " +
@@ -141,7 +143,7 @@ class Utilities : Extension() {
 					return@action
 				}
 
-				val actionLogId = getFromConfig("modActionLog") ?: return@action
+				val actionLogId = getFromConfigPrivateResponse("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 
@@ -154,7 +156,7 @@ class Utilities : Extension() {
 
 				respond { content = "Presence set to `${arguments.presenceArgument}`" }
 
-				ResponseHelper.responseEmbedInChannel(
+				responseEmbedInChannel(
 					actionLog,
 					"Presence Changed",
 					"Lily's presence has been set to `${arguments.presenceArgument}`",

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Utilities.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Utilities.kt
@@ -28,6 +28,7 @@ import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.ONLINE_STATUS_CHANNEL
 import net.irisshaders.lilybot.utils.ResponseHelper
 import net.irisshaders.lilybot.utils.TEST_GUILD_ID
+import net.irisshaders.lilybot.utils.getFromConfig
 import kotlin.time.ExperimentalTime
 
 @Suppress("DuplicatedCode")
@@ -84,12 +85,7 @@ class Utilities : Extension() {
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-
-				if (actionLogId == null) {
-					respond { content = "**Error:** Unable to access a config for this guild! Have you set it?" }
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 				val targetChannel: MessageChannelBehavior = if (arguments.targetChannel == null) {
@@ -145,12 +141,7 @@ class Utilities : Extension() {
 					return@action
 				}
 
-				val actionLogId = DatabaseHelper.selectInConfig(guild!!.id, "modActionLog")
-
-				if (actionLogId == null) {
-					respond { content = "**Error:** Unable to access a config for this guild! Have you set it?" }
-					return@action
-				}
+				val actionLogId = getFromConfig("modActionLog") ?: return@action
 
 				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Utilities.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Utilities.kt
@@ -31,7 +31,6 @@ import net.irisshaders.lilybot.utils.getFromConfigPrivateResponse
 import net.irisshaders.lilybot.utils.responseEmbedInChannel
 import kotlin.time.ExperimentalTime
 
-@Suppress("DuplicatedCode")
 class Utilities : Extension() {
 	override val name = "utilities"
 

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/ResponseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/ResponseHelper.kt
@@ -10,52 +10,50 @@ import dev.kord.core.entity.User
 import dev.kord.rest.builder.message.create.embed
 import kotlinx.datetime.Clock
 
-object ResponseHelper {
-    /**
-     * Using the provided [channel] an [embed] will be returned, populated by the fields specified by the user
-     *
-     * @param channel The channel that the embed will be created in.
-     * @param embedTitle The title to set the embed to, or null to set no title.
-     * @param embedDescription The description of the embed. If null, the description will be empty.
-     * @param embedColor The color to set the embed to. If null, the embed will be coloured black.
-     * @param requestedBy The user that requested the embed. If null, the footer will be empty.
-     * @return An embed in the channel
-     * @author Maximumpower55, NoComment1105
-     */
-    suspend fun responseEmbedInChannel(channel: MessageChannelBehavior, embedTitle: String?,
-									   embedDescription: String?, embedColor: Color?, requestedBy: User?): Message {
-        return channel.createEmbed {
-            if (embedTitle != null) title = embedTitle
-            if (embedDescription != null) description = embedDescription
-            color = embedColor ?: DISCORD_BLACK
-            timestamp = Clock.System.now()
-            if (requestedBy != null) {
-                footer {
-                    text = requestedBy.tag
-                    icon = requestedBy.avatar?.url
-                }
-            }
-        }
-    }
-
-	/**
-	 * Using the provided [User], a DM [embed] is sent to the said [User]
-	 *
-	 * @param user The user you wish to DM
-	 * @param embedTitle The title of the embed, or null to set no title
-	 * @param embedDescription The description of the embed, or null to set no description
-	 * @param embedColor The colour of the embed, or [DISCORD_BLACK] if null
-	 * @return An embed that is DM'd to the user
-	 * @author NoComment1105
-	 */
-	suspend fun userDMEmbed(user: User, embedTitle: String?, embedDescription: String?, embedColor: Color?): Message? {
-		return user.dm {
-			embed {
-				if (embedTitle != null) title = embedTitle
-				if (embedDescription != null) description = embedDescription
-				color = embedColor ?: DISCORD_BLACK
-				timestamp = Clock.System.now()
+/**
+ * Using the provided [channel] an [embed] will be returned, populated by the fields specified by the user
+ *
+ * @param channel The channel that the embed will be created in.
+ * @param embedTitle The title to set the embed to, or null to set no title.
+ * @param embedDescription The description of the embed. If null, the description will be empty.
+ * @param embedColor The color to set the embed to. If null, the embed will be coloured black.
+ * @param requestedBy The user that requested the embed. If null, the footer will be empty.
+ * @return An embed in the channel
+ * @author Maximumpower55, NoComment1105
+ */
+suspend fun responseEmbedInChannel(channel: MessageChannelBehavior, embedTitle: String?,
+								   embedDescription: String?, embedColor: Color?, requestedBy: User?): Message {
+	return channel.createEmbed {
+		if (embedTitle != null) title = embedTitle
+		if (embedDescription != null) description = embedDescription
+		color = embedColor ?: DISCORD_BLACK
+		timestamp = Clock.System.now()
+		if (requestedBy != null) {
+			footer {
+				text = requestedBy.tag
+				icon = requestedBy.avatar?.url
 			}
+		}
+	}
+}
+
+/**
+ * Using the provided [User], a DM [embed] is sent to the said [User]
+ *
+ * @param user The user you wish to DM
+ * @param embedTitle The title of the embed, or null to set no title
+ * @param embedDescription The description of the embed, or null to set no description
+ * @param embedColor The colour of the embed, or [DISCORD_BLACK] if null
+ * @return An embed that is DM'd to the user
+ * @author NoComment1105
+ */
+suspend fun userDMEmbed(user: User, embedTitle: String?, embedDescription: String?, embedColor: Color?): Message? {
+	return user.dm {
+		embed {
+			if (embedTitle != null) title = embedTitle
+			if (embedDescription != null) description = embedDescription
+			color = embedColor ?: DISCORD_BLACK
+			timestamp = Clock.System.now()
 		}
 	}
 }

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
@@ -1,0 +1,38 @@
+package net.irisshaders.lilybot.utils
+
+import com.kotlindiscord.kord.extensions.commands.application.message.EphemeralMessageCommandContext
+import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
+import com.kotlindiscord.kord.extensions.events.EventContext
+import com.kotlindiscord.kord.extensions.events.EventHandler
+import com.kotlindiscord.kord.extensions.types.edit
+import com.kotlindiscord.kord.extensions.types.respond
+import dev.kord.core.entity.channel.thread.ThreadChannel
+import dev.kord.gateway.Event
+import kotlinx.coroutines.flow.toList
+
+suspend fun EphemeralSlashCommandContext<*>.getFromConfig(inputColumn: String) =
+	DatabaseHelper.selectInConfig(guild!!.id, inputColumn) ?: run {
+		respond {
+			content = "**Error:** Unable to access config for this guild! Is your configuration set?"
+		}
+		null
+}
+
+suspend fun EphemeralSlashCommandContext<*>.getFromConfigPublicResponse(inputColumn: String) =
+	DatabaseHelper.selectInConfig(guild!!.id, inputColumn) ?: run {
+		respond {
+			content = "**Error:** Unable to access config for this guild! Please inform a member of staff!"
+		}
+		null
+}
+
+suspend fun EphemeralMessageCommandContext.getFromConfig(inputColumn: String) =
+	DatabaseHelper.selectInConfig(guild!!.id, inputColumn) ?: run {
+		respond {
+			content = "**Error:** Unable to access config for this guild! Please inform a member of staff!"
+		}
+		null
+}
+
+
+

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
@@ -61,12 +61,18 @@ suspend fun EphemeralMessageCommandContext.getFromConfigPublicResponse(inputColu
 		null
 }
 
-
+/**
+ * This is a simple function to check if the channel a command is being run in is a thread or not. If not, it informs
+ * the user. It should be handled with an if statement to return the action, depending on your desired response
+ *
+ * @return Boolean. True if the channel is a thread, false if not
+ * @author NoComment1105
+ */
 suspend fun EphemeralSlashCommandContext<*>.isThread(): Boolean {
 	return if (channel.asChannel() is ThreadChannel) {
 		kotlin.run {
 			edit {
-				content = "This isn't a thread :person_facepalming:"
+				content = "**Error:** This isn't a thread!"
 			}
 		}
 		true

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
@@ -2,15 +2,19 @@ package net.irisshaders.lilybot.utils
 
 import com.kotlindiscord.kord.extensions.commands.application.message.EphemeralMessageCommandContext
 import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
-import com.kotlindiscord.kord.extensions.events.EventContext
-import com.kotlindiscord.kord.extensions.events.EventHandler
-import com.kotlindiscord.kord.extensions.types.edit
 import com.kotlindiscord.kord.extensions.types.respond
-import dev.kord.core.entity.channel.thread.ThreadChannel
-import dev.kord.gateway.Event
-import kotlinx.coroutines.flow.toList
 
-suspend fun EphemeralSlashCommandContext<*>.getFromConfig(inputColumn: String) =
+/**
+ * This is a simple function to get a value from the configuration database in an ephemeral slash command context,
+ * null check it, and respond accordingly. It takes a string input of the column that is requested and gets it, if it's
+ * null a private error message (i.e. for commands staff run), and null is returned. If null this should be handled with
+ * an elvis operator to return the action.
+ *
+ * @param inputColumn The column you wish to get from the database
+ * @return The column value from the database or null
+ * @author NoComment1105
+ */
+suspend fun EphemeralSlashCommandContext<*>.getFromConfigPrivateResponse(inputColumn: String) =
 	DatabaseHelper.selectInConfig(guild!!.id, inputColumn) ?: run {
 		respond {
 			content = "**Error:** Unable to access config for this guild! Is your configuration set?"
@@ -18,6 +22,17 @@ suspend fun EphemeralSlashCommandContext<*>.getFromConfig(inputColumn: String) =
 		null
 }
 
+
+/**
+ * This is a simple function to get a value from the configuration database in an ephemeral slash command context,
+ * null check it, and respond accordingly. It takes a string input of the column that is requested and gets it, if it's
+ * null a public error message (i.e. for commands the people run), and null is returned. If null this should be handled
+ * with an elvis operator to return the action.
+ *
+ * @param inputColumn The column you wish to get from the database
+ * @return The column value from the database or a public error and null
+ * @author NoComment1105
+ */
 suspend fun EphemeralSlashCommandContext<*>.getFromConfigPublicResponse(inputColumn: String) =
 	DatabaseHelper.selectInConfig(guild!!.id, inputColumn) ?: run {
 		respond {
@@ -26,13 +41,20 @@ suspend fun EphemeralSlashCommandContext<*>.getFromConfigPublicResponse(inputCol
 		null
 }
 
-suspend fun EphemeralMessageCommandContext.getFromConfig(inputColumn: String) =
+/**
+ * This is a simple function to get a value from the configuration database in an ephemeral message command context,
+ * null check it, and respond accordingly. It takes a string input of the column that is requested and gets it, if it's
+ * null a private error message (i.e. for commands staff run), and null is returned. If null this should be handled with
+ * an elvis operator to return the action.
+ *
+ * @param inputColumn The column you wish to get from the database
+ * @return The column value from the database or a private error and null
+ * @author NoComment1105
+ */
+suspend fun EphemeralMessageCommandContext.getFromConfigPublicResponse(inputColumn: String) =
 	DatabaseHelper.selectInConfig(guild!!.id, inputColumn) ?: run {
 		respond {
 			content = "**Error:** Unable to access config for this guild! Please inform a member of staff!"
 		}
 		null
 }
-
-
-

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
@@ -2,7 +2,9 @@ package net.irisshaders.lilybot.utils
 
 import com.kotlindiscord.kord.extensions.commands.application.message.EphemeralMessageCommandContext
 import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
+import com.kotlindiscord.kord.extensions.types.edit
 import com.kotlindiscord.kord.extensions.types.respond
+import dev.kord.core.entity.channel.thread.ThreadChannel
 
 /**
  * This is a simple function to get a value from the configuration database in an ephemeral slash command context,
@@ -57,4 +59,18 @@ suspend fun EphemeralMessageCommandContext.getFromConfigPublicResponse(inputColu
 			content = "**Error:** Unable to access config for this guild! Please inform a member of staff!"
 		}
 		null
+}
+
+
+suspend fun EphemeralSlashCommandContext<*>.isThread(): Boolean {
+	return if (channel.asChannel() is ThreadChannel) {
+		kotlin.run {
+			edit {
+				content = "This isn't a thread :person_facepalming:"
+			}
+		}
+		true
+	} else {
+		false
+	}
 }

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
@@ -2,9 +2,7 @@ package net.irisshaders.lilybot.utils
 
 import com.kotlindiscord.kord.extensions.commands.application.message.EphemeralMessageCommandContext
 import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
-import com.kotlindiscord.kord.extensions.types.edit
 import com.kotlindiscord.kord.extensions.types.respond
-import dev.kord.core.entity.channel.thread.ThreadChannel
 
 /**
  * This is a simple function to get a value from the configuration database in an ephemeral slash command context,
@@ -60,22 +58,3 @@ suspend fun EphemeralMessageCommandContext.getFromConfigPublicResponse(inputColu
 		}
 		null
 }
-
-/**
- * This is a simple function to check if the channel a command is being run in is a thread or not. If not, it informs
- * the user. It should be handled with an if statement to return the action, depending on your desired response
- *
- * @return Boolean. True if the channel is a thread, false if not
- * @author NoComment1105
- */
-suspend fun EphemeralSlashCommandContext<*>.isThread(): Boolean =
-	if (channel.asChannel() is ThreadChannel) {
-		kotlin.run {
-			edit {
-				content = "**Error:** This isn't a thread!"
-			}
-		}
-		true
-	} else {
-		false
-	}

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
@@ -68,8 +68,8 @@ suspend fun EphemeralMessageCommandContext.getFromConfigPublicResponse(inputColu
  * @return Boolean. True if the channel is a thread, false if not
  * @author NoComment1105
  */
-suspend fun EphemeralSlashCommandContext<*>.isThread(): Boolean {
-	return if (channel.asChannel() is ThreadChannel) {
+suspend fun EphemeralSlashCommandContext<*>.isThread(): Boolean =
+	if (channel.asChannel() is ThreadChannel) {
 		kotlin.run {
 			edit {
 				content = "**Error:** This isn't a thread!"
@@ -79,4 +79,3 @@ suspend fun EphemeralSlashCommandContext<*>.isThread(): Boolean {
 	} else {
 		false
 	}
-}


### PR DESCRIPTION
This pull request creates some utility functions to allow the reduction of null checking code in commands. At the moment you can use these functions for `EphemeralSlashCommands` and `EphemeralMessageCommands`, but the `_Utils.kt` file is not restricted to just that. In the future we can populate it with other utlity functions that make things a lot easier.

Other changes include: Making `ResponseHelper` not a object anymore, it wasn't needed so I changed it to a file

**NOTE: This must be merged into monogdb branch or into develop after the #97 is merged**