### PR TITLE
Fix commands erroring when used in DM's

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/config/Config.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/config/Config.kt
@@ -1,5 +1,6 @@
 package net.irisshaders.lilybot.extensions.config
 
+import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.application.slash.ephemeralSubCommand
@@ -34,6 +35,7 @@ class Config : Extension() {
 				name = "set"
 				description = "Set the config"
 
+				check { anyGuild() }
 				check { hasPermission(Permission.Administrator) }
 
 				action {
@@ -75,6 +77,7 @@ class Config : Extension() {
 				name = "clear"
 				description = "Clear the config!"
 
+				check { anyGuild() }
 				check { hasPermission(Permission.Administrator) }
 
 				action {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
@@ -4,6 +4,7 @@
 package net.irisshaders.lilybot.extensions.events
 
 import com.kotlindiscord.kord.extensions.DISCORD_PINK
+import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.event
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
@@ -23,7 +24,7 @@ class MessageDelete : Extension() {
 		 */
 		event<MessageDeleteEvent> {
 			// Don't try to create if the message is in DMs
-			check { failIf { event.guildId == null } }
+			check { anyGuild() }
 			action {
 				if (event.message?.author?.isBot == true || event.message?.author?.id == kord.selfId) return@action
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
@@ -8,6 +8,7 @@
 
 package net.irisshaders.lilybot.extensions.events
 
+import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.event
 import com.kotlindiscord.kord.extensions.utils.delete
@@ -40,7 +41,7 @@ class ThreadInviter : Extension() {
 		 */
 		event<MessageCreateEvent> {
 			// Don't try to create if the message is in DMs
-			check { failIf { event.guildId == null } }
+			check { anyGuild() }
 			// Don't try to create if the message is a slash command
 			check { failIf { event.message.type == MessageType.ChatInputCommand } }
 			// Don't try and run this if the thread is manually created

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Report.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/Report.kt
@@ -3,6 +3,7 @@
 package net.irisshaders.lilybot.extensions.moderation
 
 import com.kotlindiscord.kord.extensions.DISCORD_RED
+import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.components.components
@@ -47,6 +48,8 @@ class Report : Extension() {
 			name = "Report"
 			locking = true // To prevent the command from being run more than once concurrently
 
+			check { anyGuild() }
+
 			action {
 				val messageLogId = getConfigPublicResponse("messageLogs") ?: return@action
 				val moderatorRoleId = getConfigPublicResponse("moderatorsPing") ?: return@action
@@ -80,6 +83,8 @@ class Report : Extension() {
 			name = "manual-report"
 			description = "Manually report a message"
 			locking = true
+
+			check { anyGuild() }
 
 			action {
 				val messageLogId = getConfigPublicResponse("messageLogs") ?: return@action

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -5,6 +5,7 @@ package net.irisshaders.lilybot.extensions.moderation
 import com.kotlindiscord.kord.extensions.DISCORD_BLACK
 import com.kotlindiscord.kord.extensions.DISCORD_GREEN
 import com.kotlindiscord.kord.extensions.DISCORD_RED
+import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.converters.impl.coalescingDefaultingDuration
@@ -56,7 +57,7 @@ class TemporaryModeration : Extension() {
 			name = "clear"
 			description = "Clears messages."
 
-			// Require message managing permissions to run this command
+			check { anyGuild() }
 			check { hasPermission(Permission.ManageMessages) }
 
 			action {
@@ -97,7 +98,7 @@ class TemporaryModeration : Extension() {
 			name = "warn"
 			description = "Warn a member for any infractions."
 
-			// Require the ModerateMembers permission
+			check { anyGuild() }
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {
@@ -226,6 +227,7 @@ class TemporaryModeration : Extension() {
 			name = "remove-warn"
 			description = "Remove a warning strike from a user"
 
+			check { anyGuild() }
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {
@@ -282,7 +284,7 @@ class TemporaryModeration : Extension() {
 			name = "timeout"
 			description = "Timeout a user"
 
-			// Requires Moderate Members permission
+			check { anyGuild() }
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {
@@ -347,7 +349,7 @@ class TemporaryModeration : Extension() {
 			name = "remove-timeout"
 			description = "Remove timeout on a user"
 
-			// Requires Moderate Members permission
+			check { anyGuild() }
 			check { hasPermission(Permission.ModerateMembers) }
 
 			action {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
@@ -4,6 +4,7 @@ package net.irisshaders.lilybot.extensions.moderation
 
 import com.kotlindiscord.kord.extensions.DISCORD_BLACK
 import com.kotlindiscord.kord.extensions.DISCORD_GREEN
+import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingInt
@@ -45,7 +46,7 @@ class TerminalModeration : Extension() {
 			name = "ban"
 			description = "Bans a user."
 
-			// Require the Ban Member permission
+			check { anyGuild() }
 			check { hasPermission(Permission.BanMembers) }
 
 			action {
@@ -107,8 +108,7 @@ class TerminalModeration : Extension() {
 			name = "unban"
 			description = "Unbans a user"
 
-			// Require Ban Members permission, only this check
-			// to avoid your everyday user from unbanning people
+			check { anyGuild() }
 			check { hasPermission(Permission.BanMembers) }
 
 			action {
@@ -147,7 +147,7 @@ class TerminalModeration : Extension() {
 			name = "soft-ban"
 			description = "Soft-bans a user"
 
-			// Requires Ban Members Permission
+			check { anyGuild() }
 			check { hasPermission(Permission.BanMembers) }
 
 			action {
@@ -213,7 +213,7 @@ class TerminalModeration : Extension() {
 			name = "kick"
 			description = "Kicks a user."
 
-			// Require Kick Members permission
+			check { anyGuild() }
 			check { hasPermission(Permission.KickMembers) }
 
 			action {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ModUtilities.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ModUtilities.kt
@@ -12,6 +12,7 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
 import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.utils.hasPermission
 import dev.kord.common.entity.Permission
 import dev.kord.common.entity.PresenceStatus
 import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
@@ -39,45 +40,69 @@ class ModUtilities : Extension() {
 			name = "say"
 			description = "Say something through Lily."
 
-			check { hasPermission(Permission.ModerateMembers) }
-
 			action {
-				val actionLogId = getConfigPrivateResponse("modActionLog") ?: return@action
+				if (guild != null) {
+					if (!user.asMember(guild!!.id).hasPermission(Permission.ModerateMembers)) {
+						respond { content = "**Error:** You do not have the `Moderate Members` permission" }
+						return@action
+					}
+					val actionLogId = getConfigPrivateResponse("modActionLog") ?: return@action
 
-				val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
-				val targetChannel = if (arguments.targetChannel == null) {
-					channel
+					val actionLog = guild?.getChannel(actionLogId) as GuildMessageChannelBehavior
+					val targetChannel = if (arguments.targetChannel == null) {
+						channel
+					} else {
+						guild?.getChannel(arguments.targetChannel!!.id) as MessageChannelBehavior
+					}
+
+
+					try {
+						if (arguments.embedMessage) {
+							targetChannel.createEmbed {
+								color = DISCORD_BLURPLE
+								description = arguments.messageArgument
+								timestamp = Clock.System.now()
+							}
+						} else {
+							targetChannel.createMessage {
+								content = arguments.messageArgument
+							}
+						}
+					} catch (e: KtorRequestException) {
+						respond { content = "Lily does not have permission to send messages in this channel." }
+						return@action
+					}
+
+					respond { content = "Message sent." }
+
+					val description =
+						if (arguments.embedMessage) {
+							"/say has been used to embed `${arguments.messageArgument}` in ${targetChannel.mention}"
+						} else {
+							"/say has been used to say `${arguments.messageArgument}` in ${targetChannel.mention}"
+						}
+
+					responseEmbedInChannel(
+						actionLog,
+						"Message Sent",
+						description,
+						DISCORD_BLACK,
+						user.asUser()
+					)
 				} else {
-					guild?.getChannel(arguments.targetChannel!!.id) as MessageChannelBehavior
-				}
-
-				try {
 					if (arguments.embedMessage) {
-						targetChannel.createEmbed {
+						channel.createEmbed {
 							color = DISCORD_BLURPLE
 							description = arguments.messageArgument
 							timestamp = Clock.System.now()
 						}
 					} else {
-						targetChannel.createMessage {
+						channel.createMessage {
 							content = arguments.messageArgument
 						}
 					}
-				} catch (e: KtorRequestException) {
-					respond { content = "Lily does not have permission to send messages in this channel." }
-					return@action
+					respond { content = "Message sent!" }
 				}
-
-				respond { content = "Message sent." }
-
-				responseEmbedInChannel(
-					actionLog,
-					"Message Sent",
-					"/say has been used to " +
-							"say `${arguments.messageArgument}` in ${targetChannel.mention}",
-					DISCORD_BLACK,
-					user.asUser()
-				)
 			}
 		}
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RoleMenu.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RoleMenu.kt
@@ -1,6 +1,7 @@
 package net.irisshaders.lilybot.extensions.util
 
 import com.kotlindiscord.kord.extensions.DISCORD_BLACK
+import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingColor
@@ -38,6 +39,7 @@ class RoleMenu : Extension() {
 			name = "role-menu"
 			description = "Creates a menu that allows users to select a role."
 
+			check { anyGuild() }
 			check { hasPermission(Permission.ManageMessages) }
 
 			@Suppress("DuplicatedCode")

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -59,9 +59,9 @@ object DatabaseHelper {
 	/**
 	 * Gets the number of points the provided [inputUserId] has in the provided [inputGuildId] from the database
 	 *
-	 * @return null or the result from the database
 	 * @param inputUserId The ID of the user to get the point value for
 	 * @param inputGuildId The ID of the guild the command was run in
+	 * @return null or the result from the database
 	 * @author tempest15
 	 */
 	suspend fun getWarn(inputUserId: Snowflake, inputGuildId: Snowflake): Int {


### PR DESCRIPTION
Resolves #107

This PR fixes an issue where certain commands would throw up errors and all guild specific commands would fail to respond. This makes use of KordEx's built in `anyGuild()` check to verify they're run in a guild. It also switches out some manual checks for dms for this function too, just for code clean-ness.

Some adjustments were made to the say command, to make it clearer weather the message was an embed or a standard message, and to allow the command to still be used in DM's