### PR TITLE
Switch to mclo.gs for Log Uploading

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -18,7 +18,7 @@ import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.rest.builder.message.modify.actionRow
 import dev.kord.rest.builder.message.modify.embed
 import io.ktor.client.HttpClient
-import io.ktor.client.request.forms.*
+import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.post
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.Parameters

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -177,8 +177,8 @@ class LogUploading : Extension() {
 	}
 
 	@kotlinx.serialization.Serializable
-	data class logClass(val success: Boolean, val id: String? = null, val error: String? = null)
-	//setting these to null is necessary in case a value is missing, which would cause an error.
+	data class LogData(val success: Boolean, val id: String? = null, val error: String? = null)
+	// setting these to null is necessary in case a value is missing, which would cause an error.
 
 	private suspend fun postToMCLogs(text: String): String {
 		val client = HttpClient()
@@ -188,8 +188,8 @@ class LogUploading : Extension() {
 			}))
 		}.readBytes().decodeToString()
 		client.close()
-		//ignoreUnknownKeys is necessary to not cause any errors due to missing values in the JSON
-		val log = Json { ignoreUnknownKeys = true }.decodeFromString<logClass>(response)
+		// ignoreUnknownKeys is necessary to not cause any errors due to missing values in the JSON
+		val log = Json { ignoreUnknownKeys = true }.decodeFromString<LogData>(response)
 		if (log.success) {
 			return "https://mclo.gs/" + log.id
 		} else {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -195,10 +195,10 @@ class LogUploading : Extension() {
 		}.content.toByteArray().decodeToString()
 		client.close()
 		//ignoreUnknownKeys is necessary to not cause any errors due to missing values in the JSON
-		val log = Json { ignoreUnknownKeys = true}.decodeFromString<logClass>(response)
+		val log = Json { ignoreUnknownKeys = true }.decodeFromString<logClass>(response)
 		if (log.success) {
 			return "https://mclo.gs/" + log.id
-		} else{
+		} else {
 			throw Exception("Failed to upload log: " + log.error)
 		}
 	}

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -21,7 +21,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.*
 import io.ktor.client.request.post
 import io.ktor.client.statement.HttpResponse
-import io.ktor.http.*
+import io.ktor.http.Parameters
 import io.ktor.util.toByteArray
 import kotlinx.datetime.Clock
 import kotlinx.serialization.decodeFromString
@@ -120,7 +120,7 @@ class LogUploading : Extension() {
 													}
 												}
 
-													try {
+												try {
 													val response = postToHasteBin(builder.toString())
 
 													uploadMessage.edit {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -121,7 +121,7 @@ class LogUploading : Extension() {
 												}
 
 												try {
-													val response = postToHasteBin(builder.toString())
+													val response = postToMCLogs(builder.toString())
 
 													uploadMessage.edit {
 														embed {
@@ -180,7 +180,7 @@ class LogUploading : Extension() {
 	data class logClass(val success: Boolean, val id: String? = null, val error: String? = null)
 	//setting these to null is necessary in case a value is missing, which would cause an error.
 
-	private suspend fun postToHasteBin(text: String): String {
+	private suspend fun postToMCLogs(text: String): String {
 		val client = HttpClient()
 
 		val response = client.post<HttpResponse>("https://api.mclo.gs/1/log") {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -18,9 +18,10 @@ import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.rest.builder.message.modify.actionRow
 import dev.kord.rest.builder.message.modify.embed
 import io.ktor.client.HttpClient
-import io.ktor.client.request.*
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import io.ktor.client.request.forms.FormDataContent
-import io.ktor.client.statement.*
+import io.ktor.client.statement.readBytes
 import io.ktor.http.Parameters
 import kotlinx.datetime.Clock
 import kotlinx.serialization.decodeFromString

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -184,12 +184,6 @@ class LogUploading : Extension() {
 			})
 		}.content.toByteArray().decodeToString()
 		val log = Json.decodeFromString<logClass>(response)
-		/*if (response.contains("\"url\"")) {
-			response = response.substring(
-				response.indexOf(":") + 3,
-				response.length - 2
-			)
-		}*/
 		if (log.success == false){
 			throw Exception("Failed to upload log")
 			/* mclo.gs returns the error but I can't think

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -18,14 +18,10 @@ import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.rest.builder.message.modify.actionRow
 import dev.kord.rest.builder.message.modify.embed
 import io.ktor.client.HttpClient
+import io.ktor.client.request.*
 import io.ktor.client.request.forms.FormDataContent
-import io.ktor.client.request.post
-import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.*
 import io.ktor.http.Parameters
-import io.ktor.util.toByteArray
-
-
-
 import kotlinx.datetime.Clock
 import kotlinx.serialization.decodeFromString
 import net.irisshaders.lilybot.utils.responseEmbedInChannel
@@ -179,20 +175,17 @@ class LogUploading : Extension() {
 		}
 	}
 
-
 	@kotlinx.serialization.Serializable
 	data class logClass(val success: Boolean, val id: String? = null, val error: String? = null)
 	//setting these to null is necessary in case a value is missing, which would cause an error.
 
 	private suspend fun postToMCLogs(text: String): String {
 		val client = HttpClient()
-
-		val response = client.post<HttpResponse>("https://api.mclo.gs/1/log") {
-			body = FormDataContent(Parameters.build {
+		val response = client.post("https://api.mclo.gs/1/log") {
+			setBody(FormDataContent(Parameters.build {
 				append("content", text)
-			})
-
-		}.content.toByteArray().decodeToString()
+			}))
+		}.readBytes().decodeToString()
 		client.close()
 		//ignoreUnknownKeys is necessary to not cause any errors due to missing values in the JSON
 		val log = Json { ignoreUnknownKeys = true }.decodeFromString<logClass>(response)


### PR DESCRIPTION
Resolves #89 

This PR makes the switch from Hastebin to mclo.gs for Log Uploading.
By making this switch, I aim to resolve several issues we had with Hastebin such as: 
- Failure to upload due to a character limit (while not resolved, the limit is much higher, at around 10 MB)
- General sketchyness
mclo.gs is also a much better website for Log Uploading due to the following:
-  The included "Analysis" feature, indicating various things about the log
-  Automatic censoring of potentially sensitive information such as server ips
-  Being maintained by Aternos, a big server hosting platform, which ensures a stabler system