### PR TITLE
Fix threads not inviting mods when support team config isn't set

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
@@ -131,68 +131,73 @@ class ThreadInviter : Extension() {
 			check { failIf(event.channel.member != null) }
 
 			action {
-				// Try to get the moderator ping role from the config. If a config is not set, return@action
-				val moderatorRoleId =
-					DatabaseHelper.getConfig(event.channel.guildId, "moderatorsPing") ?: return@action
+				val moderatorRoleId = DatabaseHelper.getConfig(event.channel.guildId, "moderatorsPing")
 				val supportTeamId = DatabaseHelper.getConfig(event.channel.guildId, "supportTeam")
-					?: return@action
-				val supportChannelId =
-					DatabaseHelper.getConfig(event.channel.guildId, "supportChannel") ?: return@action
+				val supportChannelId = DatabaseHelper.getConfig(event.channel.guildId, "supportChannel")
 
 				if (
-					try {
-						event.channel.parentId == supportChannelId
-					} catch (e: NumberFormatException) {
-						false
-					}
+					supportTeamId != null ||
+					supportChannelId != null
 				) {
-					val threadOwner = event.channel.owner.asUser()
-					val supportRole = event.channel.guild.getRole(supportTeamId)
+					if (
+						try {
+							event.channel.parentId == supportChannelId
+						} catch (e: NumberFormatException) {
+							false
+						}
+					) {
+						val threadOwner = event.channel.owner.asUser()
+						val supportRole = event.channel.guild.getRole(supportTeamId!!)
 
-					event.channel.withTyping { delay(2.seconds) }
-					val message = event.channel.createMessage(
-						content = "Hello there! Since you're in the support channel, I'll just grab the support" +
-								" team for you..."
-					)
+						event.channel.withTyping { delay(2.seconds) }
+						val message = event.channel.createMessage(
+							content = "Hello there! Since you're in the support channel, I'll just grab the support" +
+									" team for you..."
+						)
 
-					event.channel.withTyping { delay(4.seconds) }
-					message.edit { content = "${supportRole.mention}, could you please help this person!" }
+						event.channel.withTyping { delay(4.seconds) }
+						message.edit { content = "${supportRole.mention}, could you please help this person!" }
 
-					event.channel.withTyping { delay(3.seconds) }
-					message.edit {
-						content = "Welcome to your support thread, ${threadOwner.mention}\nNext time though," +
-								" you can just send a message in <#$supportChannelId> and I'll automatically" +
-								" make a thread for you"
+						event.channel.withTyping { delay(3.seconds) }
+						message.edit {
+							content = "Welcome to your support thread, ${threadOwner.mention}\nNext time though," +
+									" you can just send a message in <#$supportChannelId> and I'll automatically" +
+									" make a thread for you!"
+						}
 					}
 				}
 
 				if (
-					try {
-						event.channel.parentId != supportChannelId
-					} catch (e: NumberFormatException) {
-						false
-					}
+					moderatorRoleId != null
 				) {
-					val threadOwner = event.channel.owner.asUser()
-					val modRole = event.channel.guild.getRole((moderatorRoleId))
+					if (
+						try {
+							event.channel.parentId != supportChannelId
+						} catch (e: NumberFormatException) {
+							false
+						}
+					) {
+						val threadOwner = event.channel.owner.asUser()
+						val modRole = event.channel.guild.getRole((moderatorRoleId))
 
-					event.channel.withTyping { delay(2.seconds) }
-					val message = event.channel.createMessage(
-						content = "Hello there! Lemme just grab the moderators..."
-					)
+						event.channel.withTyping { delay(2.seconds) }
+						val message = event.channel.createMessage(
+							content = "Hello there! Lemme just grab the moderators..."
+						)
 
-					event.channel.withTyping { delay(4.seconds) }
-					message.edit { content = "${modRole.mention}, welcome to the thread!" }
+						event.channel.withTyping { delay(4.seconds) }
+						message.edit { content = "${modRole.mention}, welcome to the thread!" }
 
-					event.channel.withTyping { delay(4.seconds) }
-					message.edit {
-						content = "Welcome to your thread, ${threadOwner.mention}\nOnce you're finished, use" +
-								" `/thread archive` to close it. If you want to change the thread name, use" +
-								" `/thread rename` to do so"
+						event.channel.withTyping { delay(4.seconds) }
+						message.edit {
+							content = "Welcome to your thread, ${threadOwner.mention}\nOnce you're finished, use" +
+									" `/thread archive` to close it. If you want to change the thread name, use" +
+									" `/thread rename` to do so."
+						}
+
+						delay(20.seconds)
+						message.delete("Mods have been invited, message can go now!")
 					}
-
-					delay(20.seconds)
-					message.delete("Mods have been invited, message can go now!")
 				}
 			}
 		}

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
@@ -156,13 +156,15 @@ class ThreadInviter : Extension() {
 						)
 
 						event.channel.withTyping { delay(4.seconds) }
-						message.edit { content = "${supportRole.mention}, could you please help this person!" }
+						message.edit { content = "${supportRole.mention}, please help this person!" }
 
 						event.channel.withTyping { delay(3.seconds) }
 						message.edit {
 							content = "Welcome to your support thread, ${threadOwner.mention}\nNext time though," +
 									" you can just send a message in <#$supportChannelId> and I'll automatically" +
-									" make a thread for you!"
+									" make a thread for you!\n\nOnce you're finished, use `/thread archive` to close" +
+									" your thread. If you want to change the thread name, use `/thread rename`" +
+									" to do so."
 						}
 					}
 				}


### PR DESCRIPTION
Urgent.

This PR as stated fixes a bug with the mod inviting. Prior to this we accidentally just shut off the action if support team was null, now we get the value and check if it's not null in an if, before proceeding to do what we used to do and invite mods to the thread