### PR TITLE
Add basic error handling to log upload

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -151,7 +151,7 @@ class LogUploading : Extension() {
 														}
 													}
 													// Capture Exception to Sentry
-													sentry.captureException(e, "Log Uploading failed") {
+													this.sentry.captureException(e, "Log Uploading failed") {
 														tag("log_file_name", attachmentFileName)
 														tag("extension", extension.name)
 														tag("id", eventMessage.id.toString())

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -1,6 +1,7 @@
 package net.irisshaders.lilybot.extensions.events
 
 import com.kotlindiscord.kord.extensions.DISCORD_PINK
+import com.kotlindiscord.kord.extensions.DISCORD_RED
 import com.kotlindiscord.kord.extensions.components.components
 import com.kotlindiscord.kord.extensions.components.ephemeralButton
 import com.kotlindiscord.kord.extensions.extensions.Extension
@@ -139,12 +140,15 @@ class LogUploading : Extension() {
 														}
 													}
 												} catch (e: IOException) {
-													// Just swallow this exception
-													// If something has gone wrong here, something is wrong
-													// somewhere else, so it's probably fine
-													// -----------------------------------------------------
-													// This honestly makes no sense, why would you do this?
-													// It certainly made debugging harder. - CaioMGT
+													// If the upload fails, we'll just show the error
+													uploadMessage.edit {
+														embed {
+															color = DISCORD_RED
+															title = "Failed to upload `$attachmentFileName` to mclo.gs"
+															timestamp = Clock.System.now()
+															description = "Error: " + e.toString()
+														}
+													}
 												}
 											} else {
 												respond { content = "Only the uploader can use this menu." }

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -149,6 +149,7 @@ class LogUploading : Extension() {
 															description = "Error: " + e.toString()
 														}
 													}
+													e.printStackTrace()
 												}
 											} else {
 												respond { content = "Only the uploader can use this menu." }

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -148,6 +148,10 @@ class LogUploading : Extension() {
 															title = "Failed to upload `$attachmentFileName` to mclo.gs"
 															timestamp = Clock.System.now()
 															description = "Error: " + e.toString()
+															footer {
+																text = "Uploaded by ${eventMessage.author?.tag}"
+																icon = eventMessage.author?.avatar?.url
+															}
 														}
 													}
 													// Capture Exception to Sentry

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -6,6 +6,7 @@ import com.kotlindiscord.kord.extensions.components.components
 import com.kotlindiscord.kord.extensions.components.ephemeralButton
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.event
+import com.kotlindiscord.kord.extensions.sentry.tag
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.utils.download
 import dev.kord.common.entity.ButtonStyle
@@ -148,6 +149,12 @@ class LogUploading : Extension() {
 															timestamp = Clock.System.now()
 															description = "Error: " + e.toString()
 														}
+													}
+													// Capture Exception to Sentry
+													sentry.captureException(e, "Log Uploading failed") {
+														tag("log_file_name", attachmentFileName)
+														tag("extension", extension.name)
+														tag("id", eventMessage.id.toString())
 													}
 													e.printStackTrace()
 												}


### PR DESCRIPTION
Resolves #114  
Adds basic error handling to log uploads, by warning the user about it.
The old system literally ignored errors, so it looked like the upload hanged for the user.
While still not proper error handling, It's better than nothing