### PR TITLE
Add a thread ownership system

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
@@ -38,30 +38,29 @@ class ThreadInviter : Extension() {
 		 * @author IMS212
 		 */
 		event<MessageCreateEvent> {
-			// Don't try to create if the message is in DMs
+			/*
+			Don't try to create a thread if
+			 - the message is in DMs
+			 - a config isn't set
+			 - the message is a slash command
+			 - the thread was manually created or the message is already in a thread
+			 - the message was sent by Lily or another bot
+			 - the message is in an announcements channel
+			 */
 			check { anyGuild() }
-			// Don't try to create if the message is a slash command
-			check { failIf { event.message.type == MessageType.ChatInputCommand } }
-			// Don't try and run this if the thread is manually created
+			check { configPresent() }
 			check {
 			    failIf {
-			        event.message.type == MessageType.ThreadCreated ||
-					event.message.type == MessageType.ThreadStarterMessage
-			    }
-			}
-			// Don't try and create if Lily or another bot sent the message
-			check { failIf { event.message.author?.id == kord.selfId || event.message.author?.isBot == true } }
-			// Don't try to create if the message is already in a thread
-			check { failIf { event.message.getChannel() is TextChannelThread } }
-			// Don't try to create if the message is in an announcements channel
-			check {
-			    failIf {
-			        event.message.getChannel() is NewsChannel ||
+					event.message.type == MessageType.ChatInputCommand ||
+					event.message.type == MessageType.ThreadCreated ||
+					event.message.type == MessageType.ThreadStarterMessage ||
+					event.message.getChannel() is TextChannelThread ||
+					event.message.author?.id == kord.selfId ||
+					event.message.author?.isBot == true ||
+					event.message.getChannel() is NewsChannel ||
 					event.message.getChannel() is NewsChannelThread
 			    }
 			}
-
-			check { configPresent() }
 			action {
 				val config = DatabaseHelper.getConfig(event.guildId!!)!!
 
@@ -74,14 +73,13 @@ class ThreadInviter : Extension() {
 				val guild = event.getGuild()
 				val supportChannel = guild?.getChannel(config.supportChannel) as MessageChannelBehavior
 
-				// fail if the message is not in the support channel
 				if (textChannel != supportChannel) return@action
 
-				// TODO: this is incredibly stupid, there has to be a better way to do this.
-				textChannel.activeThreads.collect {
-					if (it.name == "Support thread for " + event.member!!.asUser().username) {
+				DatabaseHelper.getOwnerThreads(event.member!!.id).forEach {
+					val thread = guild.getChannel(it.threadId) as TextChannelThread
+					if (thread.parent == supportChannel) {
 						userThreadExists = true
-						existingUserThread = it
+						existingUserThread = thread
 					}
 				}
 
@@ -100,6 +98,9 @@ class ThreadInviter : Extension() {
 							"Support thread for " + event.member!!.asUser().username,
 							ArchiveDuration.Hour
 						)
+
+					DatabaseHelper.setThreadOwner(thread.id, event.member!!.id)
+
 					val editMessage = thread.createMessage("edit message")
 
 					editMessage.edit {
@@ -139,6 +140,8 @@ class ThreadInviter : Extension() {
 				val config = DatabaseHelper.getConfig(event.channel.guildId)!!
 				val modRole = event.channel.guild.getRole(config.moderatorsPing)
 				val threadOwner = event.channel.owner.asUser()
+
+				DatabaseHelper.setThreadOwner(event.channel.id, threadOwner.id)
 
 				var supportConfigSet = true
 				if (config.supportTeam == null || config.supportChannel == null) {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ThreadControl.kt
@@ -8,15 +8,19 @@ package net.irisshaders.lilybot.extensions.util
 
 import com.kotlindiscord.kord.extensions.checks.isInThread
 import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
 import com.kotlindiscord.kord.extensions.commands.application.slash.ephemeralSubCommand
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingBoolean
+import com.kotlindiscord.kord.extensions.commands.converters.impl.member
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.publicSlashCommand
 import com.kotlindiscord.kord.extensions.types.edit
+import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.utils.hasPermission
 import dev.kord.common.entity.Permission
 import dev.kord.core.behavior.channel.threads.edit
+import dev.kord.core.entity.Member
 import dev.kord.core.entity.channel.thread.ThreadChannel
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.configPresent
@@ -40,24 +44,15 @@ class ThreadControl : Extension() {
 				action {
 					val threadChannel = channel.asChannel() as ThreadChannel
 					val member = user.asMember(guild!!.id)
+					if (!ownsThreadOrModerator(threadChannel, member)) return@action
 
-					val databaseThreadOwner = DatabaseHelper.getThreadOwner(threadChannel.id)
+					threadChannel.edit {
+						name = arguments.newThreadName
+						reason = "Renamed by ${member.tag}"
+					}
 
-					if (member.hasPermission(Permission.ModerateMembers) || databaseThreadOwner == member.id) {
-						threadChannel.edit {
-							name = arguments.newThreadName
-
-							reason = "Renamed by ${member.tag}"
-						}
-						edit {
-							content = "Thread Renamed!"
-						}
-
-						return@action
-					} else {
-						edit { content = "**Error:** This is not your thread!" }
-
-						return@action
+					respond {
+						content = "Thread Renamed!"
 					}
 				}
 			}
@@ -72,42 +67,72 @@ class ThreadControl : Extension() {
 				action {
 					val threadChannel = channel.asChannel() as ThreadChannel
 					val member = user.asMember(guild!!.id)
-
-					val databaseThreadOwner = DatabaseHelper.getThreadOwner(threadChannel.id)
+					if (!ownsThreadOrModerator(threadChannel, member)) return@action
 
 					if (threadChannel.isArchived) {
 						edit { content = "**Error:** This channel is already archived!" }
-
 						return@action
 					}
 
-					if (member.hasPermission(Permission.ModerateMembers) || databaseThreadOwner == member.id) {
-						threadChannel.edit {
-							this.archived = true
-							this.locked = arguments.lock
+					threadChannel.edit {
+						this.archived = true
+						this.locked = arguments.lock && member.hasPermission(Permission.ModerateMembers)
 
-							reason = "Archived by ${user.asUser().tag}"
+						reason = "Archived by ${user.asUser().tag}"
+					}
+
+					respond {
+						content = "Thread archived"
+						if (arguments.lock && member.hasPermission(Permission.ModerateMembers)) {
+							content += " and locked"
 						}
-
-						edit {
-							content = "Thread archived"
-
-							if (arguments.lock) content += " and locked"
-
-							content += "!"
-						}
-
-						return@action
-					} else {
-						edit { content = "**Error:** This is not your thread!" }
-
-						return@action
+						content += "!"
 					}
 				}
 			}
 
-			// todo add pin message command
-			// todo add transfer ownership command
+			ephemeralSubCommand(::ThreadTransferArgs) {
+				name = "transfer"
+				description = "Transfer ownership of this thread"
+
+				check { isInThread() }
+				check { configPresent() }
+
+				action {
+					val threadChannel = channel.asChannel() as ThreadChannel
+					val member = user.asMember(guild!!.id)
+
+					var oldOwnerId = DatabaseHelper.getThreadOwner(threadChannel.id)
+					if (oldOwnerId == null) {
+						restoreDefaultOwner(threadChannel)
+						oldOwnerId = threadChannel.ownerId
+					}
+					val oldOwner = guild!!.getMember(oldOwnerId)
+
+					if (!ownsThreadOrModerator(threadChannel, member)) return@action
+
+					if (arguments.newOwner.id == oldOwnerId) {
+						respond { content = "That person already owns the thread!" }
+						return@action
+					}
+
+					if (arguments.newOwner.isBot) {
+						respond { content = "You cannot transfer ownership of a thread to a bot." }
+						return@action
+					}
+
+					DatabaseHelper.setThreadOwner(threadChannel.id, arguments.newOwner.id)
+
+					respond { content = "Ownership transferred." }
+
+					var content = "Thread ownership transferred from ${oldOwner.mention} " +
+							"to ${arguments.newOwner.mention}."
+
+					if (member != oldOwner) content += " Transferred by ${member.mention}"
+
+					threadChannel.createMessage(content)
+				}
+			}
 		}
 	}
 
@@ -121,8 +146,31 @@ class ThreadControl : Extension() {
 	inner class ThreadArchiveArgs : Arguments() {
 		val lock by defaultingBoolean {
 			name = "lock"
-			description = "Whether to lock the thread. Default is false"
+			description = "Whether to lock the thread if you are a moderator. Default is false"
 			defaultValue = false
 		}
+	}
+
+	inner class ThreadTransferArgs : Arguments() {
+		val newOwner by member {
+			name = "newOwner"
+			description = "The user you want to transfer ownership of the thread to"
+		}
+	}
+
+	private suspend fun EphemeralSlashCommandContext<*>.ownsThreadOrModerator
+				(inputThread: ThreadChannel, inputMember: Member): Boolean {
+		val databaseThreadOwner = DatabaseHelper.getThreadOwner(inputThread.id)
+
+		if (inputMember.hasPermission(Permission.ModerateMembers) || databaseThreadOwner == inputMember.id) {
+			return true
+		}
+
+		respond { content = "**Error:** This is not your thread!" }
+		return false
+	}
+
+	private suspend fun restoreDefaultOwner(inputThread: ThreadChannel) {
+		DatabaseHelper.setThreadOwner(inputThread.id, inputThread.ownerId)
 	}
 }

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -157,6 +157,48 @@ object DatabaseHelper {
 	}
 
 	/**
+	 * Using the provided [inputThreadId] the owner's ID or null is returned from the database.
+	 *
+	 * @param [inputThreadId] The ID of the thread you wish to find the owner for
+	 *
+	 * @return null or the thread owner's ID
+	 * @author tempest15
+	 */
+	suspend fun getThreadOwner(inputThreadId: Snowflake): Snowflake? {
+		val collection = database.getCollection<ThreadData>()
+		val selectedThread = collection.findOne(ThreadData::threadId eq inputThreadId) ?: return null
+		return selectedThread.ownerId
+	}
+
+	/**
+	 * Using the provided [inputOwnerId] the list of threads that person owns is returned from the database.
+	 *
+	 * @param [inputOwnerId] The ID of the member whose threads you wish to find
+	 *
+	 * @return null or a list of threads the member owns
+	 * @author tempest15
+	 */
+	suspend fun getOwnerThreads(inputOwnerId: Snowflake): List<ThreadData> {
+		val collection = database.getCollection<ThreadData>()
+		return collection.find(ThreadData::ownerId eq inputOwnerId).toList()
+	}
+
+	/**
+	 * Add or update the ownership of the given [inputThreadId] to the given [newOwnerId].
+	 *
+	 * @param [inputThreadId] The ID of the thread you wish to update or set the owner for
+	 * @param [newOwnerId] The new owner of the thread
+	 *
+	 * @return null or the thread owner's ID
+	 * @author tempest15
+	 */
+	suspend fun setThreadOwner(inputThreadId: Snowflake, newOwnerId: Snowflake) {
+		val collection = database.getCollection<ThreadData>()
+		collection.deleteOne(ThreadData::threadId eq inputThreadId)
+		collection.insertOne(ThreadData(inputThreadId, newOwnerId))
+	}
+
+	/**
 	 * Adds a tag to the database, using the provided parameters.
 	 *
 	 * @param inputGuildId The ID of the guild the command was run in. Used to keep things guild specific.
@@ -220,4 +262,10 @@ data class TagsData(
 	val name: String,
 	val tagTitle: String,
 	val tagValue: String
+)
+
+@Serializable
+data class ThreadData(
+	val threadId: Snowflake,
+	val ownerId: Snowflake,
 )

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -159,7 +159,7 @@ object DatabaseHelper {
 	/**
 	 * Using the provided [inputThreadId] the owner's ID or null is returned from the database.
 	 *
-	 * @param [inputThreadId] The ID of the thread you wish to find the owner for
+	 * @param inputThreadId The ID of the thread you wish to find the owner for
 	 *
 	 * @return null or the thread owner's ID
 	 * @author tempest15
@@ -173,7 +173,7 @@ object DatabaseHelper {
 	/**
 	 * Using the provided [inputOwnerId] the list of threads that person owns is returned from the database.
 	 *
-	 * @param [inputOwnerId] The ID of the member whose threads you wish to find
+	 * @param inputOwnerId The ID of the member whose threads you wish to find
 	 *
 	 * @return null or a list of threads the member owns
 	 * @author tempest15
@@ -186,8 +186,8 @@ object DatabaseHelper {
 	/**
 	 * Add or update the ownership of the given [inputThreadId] to the given [newOwnerId].
 	 *
-	 * @param [inputThreadId] The ID of the thread you wish to update or set the owner for
-	 * @param [newOwnerId] The new owner of the thread
+	 * @param inputThreadId The ID of the thread you wish to update or set the owner for
+	 * @param newOwnerId The new owner of the thread
 	 *
 	 * @return null or the thread owner's ID
 	 * @author tempest15


### PR DESCRIPTION
Adds a thread ownership system independent of Discord's built-in system. Also adds a `/thread transfer`. Resolves #115. 

TODO
- [ ] Figure out a system for when the information in the database should be deleted
- [ ] Test more

The code that currently exists is unlikely to change, so feel free to review.