### PR TITLE
Cleanup the Tags System

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Tags.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Tags.kt
@@ -6,6 +6,7 @@ import com.kotlindiscord.kord.extensions.DISCORD_RED
 import com.kotlindiscord.kord.extensions.checks.anyGuild
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalUser
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
@@ -26,25 +27,27 @@ class Tags : Extension() {
 	override val name = "tags"
 
 	override suspend fun setup() {
-		publicSlashCommand(::TagArgs) {
+		publicSlashCommand(::CallTagArgs) {
 			name = "tag"
 			description = "Call a tag from this guild! Use /tag-help for more info."
 
 			check { anyGuild() }
 
 			action {
-				if (DatabaseHelper.getTag(guild!!.id, arguments.tagName)?.name == null) {
+				if (DatabaseHelper.getTag(guild!!.id, arguments.tagName) == null) {
 					respondEphemeral {
-						content = "Unable to find tag! Does this tag exist?"
+						content = "Unable to find the requested tag. Be sure it exists and you've typed it correctly."
 					}
 					return@action
 				}
 
+				val tagFromDatabase = DatabaseHelper.getTag(guild!!.id, arguments.tagName)!!
+
 				respond {
 					embed {
 						color = DISCORD_BLURPLE
-						title = DatabaseHelper.getTag(guild!!.id, arguments.tagName)?.tagTitle!!.toString()
-						description = DatabaseHelper.getTag(guild!!.id, arguments.tagName)?.tagValue!!.toString()
+						title = tagFromDatabase.tagTitle
+						description = tagFromDatabase.tagValue
 						timestamp = Clock.System.now()
 					}
 				}
@@ -61,20 +64,20 @@ class Tags : Extension() {
 						title = "How does the tag system work?"
 						description =
 							"The tag command allows users to add guild specific 'tag' commands at runtime to their " +
-									"guild. **Tags are like custom commands**, they can do say what ever you want them " +
-									"to say.\n\n**To create a tag**, if you have the Moderate Members permission, run " +
-									"the following command:\n`/create-tag <name> <title> <value>`\nYou will be " +
-									"prompted to enter a name for the tag, a title for the tag, and the value for the" +
-									" tag. This is what will appear in the embed of your tag. You can enter any " +
-									"character you like into all of these inputs.\n\n**To use a tag**, run the " +
-									"following command\n`/tag <name>`\nYou will be prompted to enter a tag name, " +
-									"but will have an autocomplete window to aid you. The window will list all the " +
-									"tags that the guild has.\n\n**To delete a tag**, if you have the Moderate Members " +
-									"permission, run the following command\n`/delete-tag <name>`\nYou will be " +
-									"prompted to enter the name of the tag, again aided by autocomplete, and then " +
-									"the tag will be completed.\n\n**Guilds can have any number of tags they like.** The " +
-									"limit on `tagValue` for tags is 1024 characters, which is the embed description " +
-									"limit enforced by Discord"
+									"guild. **Tags are like custom commands**, they can do say what ever you want " +
+									"them to say.\n\n**To create a tag**, if you have the Moderate Members " +
+									"permission, run the following command:\n`/create-tag <name> <title> <value>`\n " +
+									"You will be prompted to enter a name for the tag, a title for the tag, and the " +
+									"value for the  tag. This is what will appear in the embed of your tag. You can " +
+									"enter any character you like into all of these inputs.\n\n**To use a tag**, " +
+									"run the following command:\n`/tag <name>`\nYou will be prompted to enter a " +
+									"tag name, but will have an autocomplete window to aid you. The window will " +
+									"list all the tags that the guild has.\n\n**To delete a tag**, if you have " +
+									"the Moderate Members permission, run the following command:\n" +
+									"`/delete-tag <name>`\nYou will be prompted to enter the name of the tag, " +
+									"again aided by autocomplete.\n\n**Guilds can have any number of tags " +
+									"they like.** The limit on `tagValue` for tags is 1024 characters, " +
+									"which is the embed description limit enforced by Discord."
 						color = DISCORD_BLURPLE
 						timestamp = Clock.System.now()
 					}
@@ -94,6 +97,13 @@ class Tags : Extension() {
 				val config = DatabaseHelper.getConfig(guild!!.id)!!
 				val actionLog = guild!!.getChannel(config.modActionLog) as GuildMessageChannelBehavior
 
+				if (DatabaseHelper.getTag(guild!!.id, arguments.tagName) != null) {
+					respond { content = "A tag with that name already exists in this guild." }
+					return@action
+				}
+
+				DatabaseHelper.setTag(guild!!.id, arguments.tagName, arguments.tagTitle, arguments.tagValue)
+
 				actionLog.createEmbed {
 					color = DISCORD_GREEN
 					title = "Tag created!"
@@ -105,7 +115,7 @@ class Tags : Extension() {
 					}
 					field {
 						name = "Tag value:"
-						value = "`${arguments.tagValue}`"
+						value = "```${arguments.tagValue}```"
 						inline = false
 					}
 					footer {
@@ -115,24 +125,22 @@ class Tags : Extension() {
 					timestamp = Clock.System.now()
 				}
 
-				DatabaseHelper.setTag(guild!!.id, arguments.tagName, arguments.tagTitle, arguments.tagValue)
-
 				respond {
 					content = "Tag: `${arguments.tagName}` created"
 				}
 			}
 		}
 
-		ephemeralSlashCommand(::TagArgs) {
+		ephemeralSlashCommand(::DeleteTagArgs) {
 			name = "tag-delete"
-			description = "Delete a tag from your guild. Use /tag-help for more info"
+			description = "Delete a tag from your guild. Use /tag-help for more info."
 
 			check { anyGuild() }
 			check { hasPermission(Permission.ModerateMembers) }
 			check { configPresent() }
 
 			action {
-				if (DatabaseHelper.getTag(guild!!.id, arguments.tagName)?.name == null) {
+				if (DatabaseHelper.getTag(guild!!.id, arguments.tagName) == null) {
 					respond {
 						content = "Unable to find tag! Does this tag exist?"
 					}
@@ -142,6 +150,8 @@ class Tags : Extension() {
 				val config = DatabaseHelper.getConfig(guild!!.id)!!
 				val actionLog = guild!!.getChannel(config.modActionLog) as GuildMessageChannelBehavior
 
+				DatabaseHelper.deleteTag(guild!!.id, arguments.tagName)
+
 				responseEmbedInChannel(
 					actionLog,
 					"Tag deleted!",
@@ -150,8 +160,6 @@ class Tags : Extension() {
 					user.asUser()
 				)
 
-				DatabaseHelper.deleteTag(guild!!.id, arguments.tagName)
-
 				respond {
 					content = "Tag: `${arguments.tagName}` deleted"
 				}
@@ -159,10 +167,33 @@ class Tags : Extension() {
 		}
 	}
 
-	inner class TagArgs : Arguments() {
+	inner class CallTagArgs : Arguments() {
 		val tagName by string {
 			name = "name"
-			description = "The name of the tag"
+			description = "The name of the tag you want to call"
+
+			autoComplete {
+				val tags = DatabaseHelper.getAllTags(data.guildId.value!!)
+				val map = mutableMapOf<String, String>()
+
+				tags.forEach {
+					map[it.name] = it.name
+				}
+
+				suggestStringMap(map)
+			}
+		}
+
+		val user by optionalUser {
+			name = "user"
+			description = "The user to mention with the tag (optional)"
+		}
+	}
+
+	inner class DeleteTagArgs : Arguments() {
+		val tagName by string {
+			name = "name"
+			description = "The name of the tag you want to delete"
 
 			autoComplete {
 				val tags = DatabaseHelper.getAllTags(data.guildId.value!!)
@@ -179,7 +210,7 @@ class Tags : Extension() {
 
 	inner class CreateTagArgs : Arguments() {
 		val tagName by string {
-			name = "tagName"
+			name = "name"
 			description = "The name of the tag you're making"
 		}
 		val tagTitle by string {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Tags.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Tags.kt
@@ -43,6 +43,10 @@ class Tags : Extension() {
 
 				val tagFromDatabase = DatabaseHelper.getTag(guild!!.id, arguments.tagName)!!
 
+				// This is not the best way to do this. Ideally the ping would be in the same message as the embed.
+				// A Discord limitation makes this not possible. Setting KordEx `allowedMentions` should work.
+				if (arguments.user != null) channel.createMessage(arguments.user!!.mention)
+
 				respond {
 					embed {
 						color = DISCORD_BLURPLE


### PR DESCRIPTION
This PR does 3 things:
1. Prevent duplicate tags from ending up in the database. You can no longer create two tags in one guild with the same name. If you try to, you'll be told to stop. You must delete a tag to replace it.
2. Add a mention argument to /tag
3. Tidy code