### PR TITLE
Change attachment logging to use media.discordapp.net instead of cdn.discordapp.com

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
@@ -47,7 +47,12 @@ class MessageDelete : Extension() {
 					if (eventMessage?.attachments != null && eventMessage.attachments.isNotEmpty()) {
 						val attachmentUrls = StringBuilder()
 						for (attachment in eventMessage.attachments) {
-							attachmentUrls.append(attachment.data.url + "\n")
+							attachmentUrls.append(
+							    "https://media.discordapp.net/attachments/" +
+									"${attachment.data.url.split("/")[4]}/" + // Get the channel
+									"${attachment.data.url.split("/")[5]}/" + // Get the message ID
+									attachment.data.filename + "\n"
+							)
 						}
 						field {
 							name = "Attachments:"


### PR DESCRIPTION
This is a small change to the logging of attachments in the delete logging, to allow for attachments to stay available for viewing for longer, since the way discord works, the cdn invalidates after a relatively short time, whereas media sticks around for a significantly longer time, allowing the logging to be more effective.

Although the branch classes this as a refactor, this PR should be classed as a trivial PR and merged once appropriate reviews have come in.