### PR TITLE
Add Environment modes

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -37,6 +37,7 @@ ONLINE_STATUS_CHANNEL=
 MONGO_URI=
 GITHUB_OAUTH=
 SENTRY_DSN=
+MODE=
 ```
 
 To get a token, join [our discord](https://discord.gg/hy2329fcTZ) and ask.
@@ -60,7 +61,10 @@ You can make one by going to [Settings/Developer settings/Personal access tokens
 and clicking generate new token. You don't need to select any scopes. DO NOT SHARE THIS WITH ANYONE.
 
 `SENTRY_DSN` is a connection string for Sentry, a logging tool.
-You can find out more about it [here]( https://sentry.io/welcome/).
+You can find out more about it [here](https://sentry.io/welcome/).
+
+`MODE` is the name of the environment you are running in. If you're doing development, you'll want "development" as your
+mode string.
 
 ## Step 4 - Starting your Mongo database
 Open a terminal window and start your Mongo database using the respective command for your OS.

--- a/docs/hosting-guide.md
+++ b/docs/hosting-guide.md
@@ -45,6 +45,7 @@ ONLINE_STATUS_CHANNEL=
 MONGO_URI=
 GITHUB_OAUTH=
 SENTRY_DSN=
+MODE=
 ```
 
 To get the token for your bot, return to the Discord developers portal for your bot,
@@ -70,6 +71,9 @@ and clicking generate new token. You don't need to select any scopes. DO NOT SHA
 
 `SENTRY_DSN` is a connection string for Sentry, a logging tool.
 You can find out more about it [here]( https://sentry.io/welcome/).
+
+`MODE` is the name of the environment you are running in. If you're running in production, you'll want "production" 
+as your mode string.
 
 ## Step 4.5 - Using Docker (optional)
 Lily does support Docker and the official production instance utilizes it.

--- a/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
@@ -1,51 +1,27 @@
-@file:OptIn(PrivilegedIntent::class)
-@file:Suppress("DEPRECATION")
-
 package net.irisshaders.lilybot
 
 import com.github.jezza.Toml
 import com.github.jezza.TomlTable
 import com.kotlindiscord.kord.extensions.ExtensibleBot
-import com.kotlindiscord.kord.extensions.modules.extra.mappings.extMappings
-import com.kotlindiscord.kord.extensions.modules.extra.phishing.DetectionAction
-import com.kotlindiscord.kord.extensions.modules.extra.phishing.extPhishing
 import com.mongodb.ConnectionString
 import com.mongodb.MongoClientSettings
-import dev.kord.gateway.Intent
-import dev.kord.gateway.PrivilegedIntent
 import mu.KotlinLogging
-import net.irisshaders.lilybot.extensions.config.Config
-import net.irisshaders.lilybot.extensions.events.LogUploading
-import net.irisshaders.lilybot.extensions.events.MemberJoinLeave
-import net.irisshaders.lilybot.extensions.events.MessageDelete
-import net.irisshaders.lilybot.extensions.events.ThreadInviter
-import net.irisshaders.lilybot.extensions.moderation.Report
-import net.irisshaders.lilybot.extensions.moderation.TemporaryModeration
-import net.irisshaders.lilybot.extensions.moderation.TerminalModeration
-import net.irisshaders.lilybot.extensions.util.CustomCommands
-import net.irisshaders.lilybot.extensions.util.Github
-import net.irisshaders.lilybot.extensions.util.ModUtilities
-import net.irisshaders.lilybot.extensions.util.PublicUtilities
-import net.irisshaders.lilybot.extensions.util.RoleMenu
-import net.irisshaders.lilybot.extensions.util.Tags
-import net.irisshaders.lilybot.extensions.util.ThreadControl
 import net.irisshaders.lilybot.utils.BOT_TOKEN
 import net.irisshaders.lilybot.utils.CUSTOM_COMMANDS_PATH
 import net.irisshaders.lilybot.utils.DatabaseHelper
-import net.irisshaders.lilybot.utils.GITHUB_OAUTH
+import net.irisshaders.lilybot.utils.MODE
 import net.irisshaders.lilybot.utils.MONGO_URI
-import net.irisshaders.lilybot.utils.SENTRY_DSN
+import net.irisshaders.lilybot.utils.Mode
+import net.irisshaders.lilybot.utils.TEST_GUILD_ID
+import net.irisshaders.lilybot.utils.addExtensions
+import net.irisshaders.lilybot.utils.common
 import org.bson.UuidRepresentation
-import org.kohsuke.github.GitHub
-import org.kohsuke.github.GitHubBuilder
 import org.litote.kmongo.coroutine.coroutine
 import org.litote.kmongo.reactivestreams.KMongo
-import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 
 val config: TomlTable = Toml.from(Files.newInputStream(Path.of(CUSTOM_COMMANDS_PATH)))
-var github: GitHub? = null
 
 // Connect to the database
 private val settings = MongoClientSettings
@@ -56,64 +32,56 @@ private val settings = MongoClientSettings
 
 private val client = KMongo.createClient(settings).coroutine
 val database = client.getDatabase("LilyBot")
-private val gitHubLogger = KotlinLogging.logger { }
+private val lilylogger = KotlinLogging.logger { }
 
 suspend fun main() {
-	val bot = ExtensibleBot(BOT_TOKEN) {
-		applicationCommands {
-			enabled = true
-		}
+	val bot = when (MODE) {
+		"production" -> setupProduction()
+		"development" -> setupDevelopment()
 
-		members {
-			lockMemberRequests = true
-			all()
-		}
-
-		intents {
-			+Intent.GuildMembers
-		}
-
-		extensions {
-			add(::Config)
-			add(::CustomCommands)
-			add(::Github)
-			add(::LogUploading)
-			add(::MemberJoinLeave)
-			add(::MessageDelete)
-			add(::ModUtilities)
-			add(::PublicUtilities)
-			add(::Report)
-			add(::RoleMenu)
-			add(::Tags)
-			add(::TemporaryModeration)
-			add(::TerminalModeration)
-			add(::ThreadControl)
-			add(::ThreadInviter)
-
-			extPhishing {
-				appName = "Lily Bot"
-				detectionAction = DetectionAction.Kick
-				logChannelName = "anti-phishing-logs"
-				requiredCommandPermission = null
-			}
-
-			extMappings { }
-
-			sentry {
-				enableIfDSN(SENTRY_DSN)
-			}
-		}
-
-		presence { playing(DatabaseHelper.getStatus()) }
-
-		try {
-			github = GitHubBuilder().withOAuthToken(GITHUB_OAUTH).build()
-			gitHubLogger.info("Logged into GitHub!")
-		} catch (exception: IOException) {
-			exception.printStackTrace()
-			gitHubLogger.error("Failed to log into GitHub!")
-		}
+		else -> error("Invalid mode: $MODE")
 	}
 
 	bot.start()
+}
+
+/**
+ * This functions adds all the features and settings that are independent of the [common] function and required for
+ * running the bot in production.
+ *
+ * @author NoComment1105
+ * @since 3.2.0
+ */
+suspend fun setupProduction() = ExtensibleBot(BOT_TOKEN) {
+	applicationCommands {
+		enabled = true
+	}
+
+	common()
+	addExtensions(Mode.PRODUCTION)
+
+	presence { playing(DatabaseHelper.getStatus()) }
+
+	lilylogger.info("Loaded into PRODUCTION mode")
+}
+
+/**
+ * This function adds all the features and settings that are independent of the [common] function and required for
+ * running the bot in development.
+ *
+ * @author NoComment1105
+ * @since 3.2.0
+ */
+suspend fun setupDevelopment() = ExtensibleBot(BOT_TOKEN) {
+	applicationCommands {
+		defaultGuild = TEST_GUILD_ID // Set default guild so we aren't waiting years for commands to appear
+		enabled = true
+	}
+
+	common()
+	addExtensions(Mode.DEVELOPMENT)
+
+	presence { playing("in development") }
+
+	lilylogger.info("Loaded into DEVELOPMENT mode")
 }

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Github.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/Github.kt
@@ -13,7 +13,7 @@ import com.kotlindiscord.kord.extensions.types.respondEphemeral
 import dev.kord.rest.builder.message.create.embed
 import io.ktor.utils.io.errors.IOException
 import kotlinx.datetime.Clock
-import net.irisshaders.lilybot.github
+import net.irisshaders.lilybot.utils.github
 import org.kohsuke.github.GHDirection
 import org.kohsuke.github.GHException
 import org.kohsuke.github.GHFileNotFoundException

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/BotSetup.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/BotSetup.kt
@@ -1,0 +1,113 @@
+@file:OptIn(PrivilegedIntent::class)
+@file:Suppress("DEPRECATION")
+
+package net.irisshaders.lilybot.utils
+
+import com.kotlindiscord.kord.extensions.builders.ExtensibleBotBuilder
+import com.kotlindiscord.kord.extensions.modules.extra.mappings.extMappings
+import com.kotlindiscord.kord.extensions.modules.extra.phishing.DetectionAction
+import com.kotlindiscord.kord.extensions.modules.extra.phishing.extPhishing
+import dev.kord.gateway.Intent
+import dev.kord.gateway.PrivilegedIntent
+import mu.KotlinLogging
+import net.irisshaders.lilybot.extensions.config.Config
+import net.irisshaders.lilybot.extensions.events.LogUploading
+import net.irisshaders.lilybot.extensions.events.MemberJoinLeave
+import net.irisshaders.lilybot.extensions.events.MessageDelete
+import net.irisshaders.lilybot.extensions.events.ThreadInviter
+import net.irisshaders.lilybot.extensions.moderation.Report
+import net.irisshaders.lilybot.extensions.moderation.TemporaryModeration
+import net.irisshaders.lilybot.extensions.moderation.TerminalModeration
+import net.irisshaders.lilybot.extensions.util.CustomCommands
+import net.irisshaders.lilybot.extensions.util.Github
+import net.irisshaders.lilybot.extensions.util.ModUtilities
+import net.irisshaders.lilybot.extensions.util.PublicUtilities
+import net.irisshaders.lilybot.extensions.util.RoleMenu
+import net.irisshaders.lilybot.extensions.util.Tags
+import net.irisshaders.lilybot.extensions.util.ThreadControl
+import org.kohsuke.github.GitHub
+import org.kohsuke.github.GitHubBuilder
+import java.io.IOException
+
+var github: GitHub? = null
+private val gitHubLogger = KotlinLogging.logger { }
+
+/**
+ * The common features for the bot that should be present across testing and production.
+ *
+ * @author NoComment1105
+ * @since 3.2.0
+ */
+suspend fun ExtensibleBotBuilder.common() {
+	members {
+		lockMemberRequests = true
+		all()
+	}
+
+	intents {
+		+Intent.GuildMembers
+	}
+
+	try {
+		github = GitHubBuilder().withOAuthToken(GITHUB_OAUTH).build()
+		gitHubLogger.info("Logged into GitHub!")
+	} catch (exception: IOException) {
+		gitHubLogger.error("Failed to log into GitHub!")
+	}
+}
+
+/**
+ * The extensions used by the bot.
+ *
+ * @param mode The [Mode] the bot is using. Defines certain extensions
+ * @author NoComment1105
+ * @since 3.2.0
+ */
+suspend fun ExtensibleBotBuilder.addExtensions(mode: Mode) {
+	extensions {
+		add(::Config)
+		add(::CustomCommands)
+		add(::Github)
+		add(::LogUploading)
+		add(::MemberJoinLeave)
+		add(::MessageDelete)
+		add(::ModUtilities)
+		add(::PublicUtilities)
+		add(::Report)
+		add(::RoleMenu)
+		add(::Tags)
+		add(::TemporaryModeration)
+		add(::TerminalModeration)
+		add(::ThreadControl)
+		add(::ThreadInviter)
+
+		if (mode == Mode.PRODUCTION) {
+			extPhishing {
+				appName = "Lily Bot"
+				detectionAction = DetectionAction.Kick
+				logChannelName = "anti-phishing-logs"
+				requiredCommandPermission = null
+			}
+
+			sentry {
+				enableIfDSN(SENTRY_DSN)
+			}
+		}
+
+		extMappings { }
+	}
+}
+
+/**
+ * The enum to store the modes for the bot.
+ *
+ * @property PRODUCTION Used for Production Mode
+ * @property DEVELOPMENT Used for Development mode
+ *
+ * @author NoComment1105
+ * @since 3.2.0
+ */
+enum class Mode {
+	PRODUCTION,
+	DEVELOPMENT
+}

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Constants.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Constants.kt
@@ -12,3 +12,6 @@ val ONLINE_STATUS_CHANNEL = Snowflake(env("ONLINE_STATUS_CHANNEL"))
 val MONGO_URI = envOrNull("MONGO_URI") ?: "mongodb://localhost:27017"
 val GITHUB_OAUTH = envOrNull("GITHUB_OAUTH")
 val SENTRY_DSN = envOrNull("SENTRY_DSN")
+
+/** The mode to use the bot in, either `production` or `development`. */
+val MODE = env("MODE")


### PR DESCRIPTION
Previously we used global commands for testing, meaning we were often waiting long periods of time for commands to appear in our clients. Now you can choose to run the bot in `development` mode which will utilise guild specific commands for the bot, and also disable the anti-phishing extension, given we have official Lilybot in our dev server, which will have the anti-phishing extension enabled.