### PR TITLE
Remove old guild data after 30 days or more

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
@@ -15,6 +15,7 @@ import dev.kord.gateway.Intent
 import dev.kord.gateway.PrivilegedIntent
 import mu.KotlinLogging
 import net.irisshaders.lilybot.extensions.config.Config
+import net.irisshaders.lilybot.extensions.config.JoinLeaveDetection
 import net.irisshaders.lilybot.extensions.events.LogUploading
 import net.irisshaders.lilybot.extensions.events.MemberJoinLeave
 import net.irisshaders.lilybot.extensions.events.MessageDelete
@@ -74,6 +75,7 @@ suspend fun main() {
 			add(::Config)
 			add(::CustomCommands)
 			add(::Github)
+			add(::JoinLeaveDetection)
 			add(::LogUploading)
 			add(::MemberJoinLeave)
 			add(::MessageDelete)

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/config/JoinLeaveDetection.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/config/JoinLeaveDetection.kt
@@ -1,0 +1,40 @@
+package net.irisshaders.lilybot.extensions.config
+
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.event
+import dev.kord.core.event.guild.MemberJoinEvent
+import dev.kord.core.event.guild.MemberLeaveEvent
+import kotlinx.datetime.Clock
+import net.irisshaders.lilybot.utils.DatabaseHelper
+
+class JoinLeaveDetection : Extension() {
+	override val name = "joinleavedetection"
+
+	override suspend fun setup() {
+		event<MemberLeaveEvent> {
+			action {
+				if (event.user.id != kord.selfId) return@action // We only care if Lily is leaving, so ignore others
+
+				val guildLeaveData = DatabaseHelper.getLeaveTime(event.guildId) ?: return@action
+
+				// This should never happen unless Lily is re-invited to a guild
+				if (guildLeaveData.guildLeaveTime != null) return@action
+
+				DatabaseHelper.setLeaveTime(event.guildId, Clock.System.now())
+			}
+		}
+
+		event<MemberJoinEvent> {
+			action {
+				if (event.member.id != kord.selfId) return@action // We only care if Lily is joining, so ignore others
+
+				val guildLeaveData = DatabaseHelper.getLeaveTime(event.guildId) ?: return@action
+
+				// If this is the case, it is first time join. Return to avoid removing things that don't exist
+				if (guildLeaveData.guildLeaveTime == null) return@action
+
+				DatabaseHelper.setLeaveTime(event.guildId, null)
+			}
+		}
+	}
+}

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/config/JoinLeaveDetection.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/config/JoinLeaveDetection.kt
@@ -2,28 +2,24 @@ package net.irisshaders.lilybot.extensions.config
 
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.event
-import dev.kord.core.event.guild.MemberJoinEvent
-import dev.kord.core.event.guild.MemberLeaveEvent
+import dev.kord.core.event.guild.GuildCreateEvent
+import dev.kord.core.event.guild.GuildDeleteEvent
 import kotlinx.datetime.Clock
 import net.irisshaders.lilybot.utils.DatabaseHelper
 
 class JoinLeaveDetection : Extension() {
-	override val name = "joinleavedetection"
+	override val name = "join-leave-detection"
 
 	override suspend fun setup() {
-		event<MemberLeaveEvent> {
+		event<GuildDeleteEvent> {
 			action {
-				if (event.user.id != kord.selfId) return@action // We only care if Lily is leaving, so ignore others
-
 				DatabaseHelper.setLeaveTime(event.guildId, Clock.System.now())
 			}
 		}
 
-		event<MemberJoinEvent> {
+		event<GuildCreateEvent> {
 			action {
-				if (event.member.id != kord.selfId) return@action // We only care if Lily is joining, so ignore others
-
-				DatabaseHelper.setLeaveTime(event.guildId, null)
+				DatabaseHelper.deleteLeaveTime(event.guild.id)
 			}
 		}
 	}

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/config/JoinLeaveDetection.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/config/JoinLeaveDetection.kt
@@ -15,11 +15,6 @@ class JoinLeaveDetection : Extension() {
 			action {
 				if (event.user.id != kord.selfId) return@action // We only care if Lily is leaving, so ignore others
 
-				val guildLeaveData = DatabaseHelper.getLeaveTime(event.guildId) ?: return@action
-
-				// This should never happen unless Lily is re-invited to a guild
-				if (guildLeaveData.guildLeaveTime != null) return@action
-
 				DatabaseHelper.setLeaveTime(event.guildId, Clock.System.now())
 			}
 		}
@@ -27,11 +22,6 @@ class JoinLeaveDetection : Extension() {
 		event<MemberJoinEvent> {
 			action {
 				if (event.member.id != kord.selfId) return@action // We only care if Lily is joining, so ignore others
-
-				val guildLeaveData = DatabaseHelper.getLeaveTime(event.guildId) ?: return@action
-
-				// If this is the case, it is first time join. Return to avoid removing things that don't exist
-				if (guildLeaveData.guildLeaveTime == null) return@action
 
 				DatabaseHelper.setLeaveTime(event.guildId, null)
 			}

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MemberJoinLeave.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MemberJoinLeave.kt
@@ -56,6 +56,8 @@ class MemberJoinLeave : Extension() {
 		/** Create an embed in the join channel on user leave */
 		event<MemberLeaveEvent> {
 			action {
+				// If it's Lily leaving, return the action, otherwise the log will fill with errors
+				if (event.user.id == kord.selfId) return@action
 				val config = DatabaseHelper.getConfig(event.guildId) ?: return@action
 
 				val eventUser = event.user

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/PublicUtilities.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/PublicUtilities.kt
@@ -59,6 +59,15 @@ class PublicUtilities : Extension() {
 		DatabaseHelper.cleanupThreadData(kord)
 
 		/**
+		 * This function is called to remove any guilds in the database that haven't had Lily in them for more than
+		 * a month. It only runs on startup
+		 *
+		 * @author NoComment1105
+		 * @since 3.2.0
+		 */
+		DatabaseHelper.cleanupGuildData()
+
+		/**
 		 * Ping Command.
 		 * @author IMS212
 		 * @since 2.0

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -269,22 +269,22 @@ object DatabaseHelper {
 	 * @author NoComment1105
 	 * @since 3.2.0
 	 */
-	suspend fun setLeaveTime(inputGuildId: Snowflake, time: Instant?) {
+	suspend fun setLeaveTime(inputGuildId: Snowflake, time: Instant) {
 		val collection = database.getCollection<GuildLeaveTimeData>()
 		collection.insertOne(GuildLeaveTimeData(inputGuildId, time))
 	}
 
 	/**
-	 * Gets the time LilyBot left a guild.
+	 * This function deletes a [GuildLeaveTimeData] from the database.
 	 *
-	 * @param inputGuildId The guild you're getting the time for
+	 * @param inputGuildId The guild to delete the [GuildLeaveTimeData] for
 	 *
-	 * @author NoComment1105
+	 * @author tempest15
 	 * @since 3.2.0
 	 */
-	suspend fun getLeaveTime(inputGuildId: Snowflake): GuildLeaveTimeData? {
+	suspend fun deleteLeaveTime(inputGuildId: Snowflake) {
 		val collection = database.getCollection<GuildLeaveTimeData>()
-		return collection.findOne(GuildLeaveTimeData::guildId eq inputGuildId)
+		collection.deleteOne(GuildLeaveTimeData::guildId eq inputGuildId)
 	}
 
 	/**
@@ -294,16 +294,16 @@ object DatabaseHelper {
 	 * @since 3.2.0
 	 */
 	suspend fun cleanupGuildData() {
-		val leaveTimeDataCollection = database.getCollection<GuildLeaveTimeData>()
-		val leaveTimeData = leaveTimeDataCollection.find().toList()
+		val collection = database.getCollection<GuildLeaveTimeData>()
+		val leaveTimeData = collection.find().toList()
 		var clearedConfigs = 0
 
 		leaveTimeData.forEach {
-			val leaveDuration = Clock.System.now() - it.guildLeaveTime!!
+			val leaveDuration = Clock.System.now() - it.guildLeaveTime
 
 			if (leaveDuration.inWholeDays > 30) {
 				clearConfig(it.guildId)
-				leaveTimeDataCollection.deleteOne(GuildLeaveTimeData::guildId eq it.guildId)
+				collection.deleteOne(GuildLeaveTimeData::guildId eq it.guildId)
 				clearedConfigs += 1
 			}
 		}
@@ -405,5 +405,5 @@ data class ThreadData(
 @Serializable
 data class GuildLeaveTimeData(
 	val guildId: Snowflake,
-	val guildLeaveTime: Instant?
+	val guildLeaveTime: Instant
 )


### PR DESCRIPTION
This PR adds code to allow us to detect when Lily bot leaves a guild by storing the Instant she left, then comparing that to the present time, and deciding whether to delete the data or not. Currently, if lily has been out of the guild for more than 30 days, the Config data and leave time data are removed from the database. If lily rejoins at any point, the leave time data is removed, and things proceed as if lily never left. Great thanks to tempest because mongo killed me.
Closes #128 