### PR TITLE
Add image capability to logging embeds

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -55,6 +55,7 @@ Name: `kick`
 Arguments:
 * `kickUser` – Person to kick - User
 * `reason` - Reason for the Kick - Optional String
+* `image` - The URL to an image to provide extra context for the action - Optional String
 
 Result: Kicks `kickUser` from the server with reason `reason`.
 
@@ -65,6 +66,7 @@ Arguments:
 * `banUser` – Person to ban - User
 * `messages` - Number of days of messages to delete - Integer
 * `reason` - Reason for the ban - Optional String
+* `image` - The URL to an image to provide extra context for the action - Optional String
 
 Result: Bans `banUser` from the server with reason `reason` and deletes any messages they sent in the last
 `messages` day(s).
@@ -84,6 +86,7 @@ Arguments:
 * `softBanUser` - Person to soft ban - User
 * `messages` - Number of days of messages to delete - Integer (default 3)
 * `reason` - Reason for the ban - Optional String
+* `image` - The URL to an image to provide extra context for the action - Optional String
 
 Result: Bans `softBanUser`, deletes the last `messages` days of messages from them, and unbans them.
 
@@ -93,6 +96,7 @@ Name: `warn`
 Arguments:
 * `warnUser` - Person to warn - User
 * `reason` - Reason for warn - Optional String
+* `image` - The URL to an image to provide extra context for the action - Optional String
 
 Result: Warns `warnUser` with a DM and adds a strike to their points total.
 Depending on their new points total, action is taken based on the below table.
@@ -112,6 +116,7 @@ Arguments:
 * `timeoutUser` - Person to timeout - User
 * `duration` - Duration of timeout - Duration [e.g. 6h or 30s] (default 6h)
 * `reason` - Reason for timeout - Optional String
+* `image` - The URL to an image to provide extra context for the action - Optional String
 
 Result: Times `timeoutUser` out for `duration`. A timeout is Discord's built-in mute function.
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -658,7 +658,7 @@ class TemporaryModeration : Extension() {
 		/** An image that the user wishes to provide for context to the kick. */
 		val image by optionalString {
 			name = "image"
-			description = "The URL to an image you'd like to provide"
+			description = "The URL to an image you'd like to provide as extra context for the action"
 		}
 	}
 
@@ -687,7 +687,7 @@ class TemporaryModeration : Extension() {
 		/** An image that the user wishes to provide for context to the kick. */
 		val image by optionalString {
 			name = "image"
-			description = "The URL to an image you'd like to provide"
+			description = "The URL to an image you'd like to provide as extra context for the action"
 		}
 	}
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -11,6 +11,7 @@ import com.kotlindiscord.kord.extensions.commands.converters.impl.coalescingDefa
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingString
 import com.kotlindiscord.kord.extensions.commands.converters.impl.int
 import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalChannel
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
 import com.kotlindiscord.kord.extensions.commands.converters.impl.user
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
@@ -215,6 +216,7 @@ class TemporaryModeration : Extension() {
 					title = "Warning"
 					color = DISCORD_BLACK
 					timestamp = Clock.System.now()
+					image = arguments.image
 
 					baseModerationEmbed(arguments.reason, userArg, user)
 					field {
@@ -339,6 +341,7 @@ class TemporaryModeration : Extension() {
 					title = "Timeout"
 					color = DISCORD_BLACK
 					timestamp = Clock.System.now()
+					image = arguments.image
 
 					baseModerationEmbed(arguments.reason, userArg, user)
 					field {
@@ -643,6 +646,12 @@ class TemporaryModeration : Extension() {
 			description = "Reason for timeout"
 			defaultValue = "No reason provided"
 		}
+
+		/** An image that the user wishes to provide for context to the kick. */
+		val image by optionalString {
+			name = "image"
+			description = "The URL to an image you'd like to provide"
+		}
 	}
 
 	inner class RemoveTimeoutArgs : Arguments() {
@@ -665,6 +674,12 @@ class TemporaryModeration : Extension() {
 			name = "reason"
 			description = "Reason for warn"
 			defaultValue = "No reason provided"
+		}
+
+		/** An image that the user wishes to provide for context to the kick. */
+		val image by optionalString {
+			name = "image"
+			description = "The URL to an image you'd like to provide"
 		}
 	}
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -115,10 +115,6 @@ class TemporaryModeration : Extension() {
 				val config = DatabaseHelper.getConfig(guild!!.id)!!
 				val actionLog = guild?.getChannel(config.modActionLog) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
-				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
-					respond { content = "Invalid Image! Please try again." }
-					return@action
-				}
 
 				isBotOrModerator(userArg, "warn") ?: return@action
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -39,6 +39,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.baseModerationEmbed
+import net.irisshaders.lilybot.utils.checkImages
 import net.irisshaders.lilybot.utils.configPresent
 import net.irisshaders.lilybot.utils.dmNotificationStatusEmbedField
 import net.irisshaders.lilybot.utils.isBotOrModerator
@@ -120,6 +121,8 @@ class TemporaryModeration : Extension() {
 				}
 
 				isBotOrModerator(userArg, "warn") ?: return@action
+
+				checkImages(arguments.image) ?: return@action
 
 				DatabaseHelper.setWarn(userArg.id, guild!!.id, false)
 				val newStrikes = DatabaseHelper.getWarn(userArg.id, guild!!.id)?.strikes
@@ -310,13 +313,11 @@ class TemporaryModeration : Extension() {
 				val actionLog = guild?.getChannel(config.modActionLog) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
 				val duration = Clock.System.now().plus(arguments.duration, TimeZone.UTC)
-				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
-					respond { content = "Invalid Image! Please try again." }
-					return@action
-				}
 
 				// Clarify the user is not bot or a moderator
 				isBotOrModerator(userArg, "timeout") ?: return@action
+
+				checkImages(arguments.image) ?: return@action
 
 				try {
 					// Run the timeout task

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -114,6 +114,10 @@ class TemporaryModeration : Extension() {
 				val config = DatabaseHelper.getConfig(guild!!.id)!!
 				val actionLog = guild?.getChannel(config.modActionLog) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
+				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
+					respond { content = "Invalid Image! Please try again." }
+					return@action
+				}
 
 				isBotOrModerator(userArg, "warn") ?: return@action
 
@@ -306,6 +310,10 @@ class TemporaryModeration : Extension() {
 				val actionLog = guild?.getChannel(config.modActionLog) as GuildMessageChannelBehavior
 				val userArg = arguments.userArgument
 				val duration = Clock.System.now().plus(arguments.duration, TimeZone.UTC)
+				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
+					respond { content = "Invalid Image! Please try again." }
+					return@action
+				}
 
 				// Clarify the user is not bot or a moderator
 				isBotOrModerator(userArg, "timeout") ?: return@action

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
@@ -25,6 +25,7 @@ import kotlinx.datetime.Clock
 import mu.KotlinLogging
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.baseModerationEmbed
+import net.irisshaders.lilybot.utils.checkImages
 import net.irisshaders.lilybot.utils.configPresent
 import net.irisshaders.lilybot.utils.dmNotificationStatusEmbedField
 import net.irisshaders.lilybot.utils.isBotOrModerator
@@ -63,10 +64,7 @@ class TerminalModeration : Extension() {
 				// Clarify the user is not a bot or moderator
 				isBotOrModerator(userArg, "ban") ?: return@action
 
-				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
-					respond { content = "Invalid Image! Please try again." }
-					return@action
-				}
+				checkImages(arguments.image) ?: return@action
 
 				// DM the user before the ban task is run, to avoid error, null if fails
 				val dm = userDMEmbed(
@@ -181,10 +179,7 @@ class TerminalModeration : Extension() {
 
 				isBotOrModerator(userArg, "soft-ban") ?: return@action
 
-				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
-					respond { content = "Invalid Image! Please try again." }
-					return@action
-				}
+				checkImages(arguments.image) ?: return@action
 
 				// DM the user before the ban task is run
 				val dm = userDMEmbed(
@@ -261,10 +256,7 @@ class TerminalModeration : Extension() {
 				// Clarify the user isn't a bot or a moderator
 				isBotOrModerator(userArg, "kick") ?: return@action
 
-				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
-					respond { content = "Invalid Image! Please try again." }
-					return@action
-				}
+				checkImages(arguments.image) ?: return@action
 
 				// DM the user about it before the kick
 				val dm = userDMEmbed(

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
@@ -8,6 +8,7 @@ import com.kotlindiscord.kord.extensions.commands.Arguments
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingInt
 import com.kotlindiscord.kord.extensions.commands.converters.impl.defaultingString
 import com.kotlindiscord.kord.extensions.commands.converters.impl.int
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalString
 import com.kotlindiscord.kord.extensions.commands.converters.impl.user
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
@@ -39,7 +40,7 @@ class TerminalModeration : Extension() {
 	override val name = "terminal-moderation"
 
 	override suspend fun setup() {
-		val logger = KotlinLogging.logger { }
+		val logger = KotlinLogging.logger("TerminalModeration")
 
 		/**
 		 * Ban command
@@ -97,6 +98,7 @@ class TerminalModeration : Extension() {
 					color = DISCORD_BLACK
 					title = "Banned a user"
 					description = "${userArg.mention} has been banned!"
+					image = arguments.image
 
 					baseModerationEmbed(arguments.reason, userArg, user)
 					field {
@@ -210,6 +212,7 @@ class TerminalModeration : Extension() {
 					color = DISCORD_BLACK
 					title = "Soft-banned a user"
 					description = "${userArg.mention} has been soft banned"
+					image = arguments.image
 
 					baseModerationEmbed(arguments.reason, userArg, user)
 					field {
@@ -274,9 +277,12 @@ class TerminalModeration : Extension() {
 					color = DISCORD_BLACK
 					title = "Kicked User"
 					description = "${userArg.mention} has been kicked"
+					image = arguments.image
 
 					baseModerationEmbed(arguments.reason, userArg, user)
 					dmNotificationStatusEmbedField(dm)
+
+					timestamp = Clock.System.now()
 				}
 			}
 		}
@@ -294,6 +300,12 @@ class TerminalModeration : Extension() {
 			name = "reason"
 			description = "The reason for the Kick"
 			defaultValue = "No Reason Provided"
+		}
+
+		/** An image that the user wishes to provide for context to the kick. */
+		val image by optionalString {
+			name = "image"
+			description = "The URL to an image you'd like to provide"
 		}
 	}
 
@@ -315,6 +327,12 @@ class TerminalModeration : Extension() {
 			name = "reason"
 			description = "The reason for the ban"
 			defaultValue = "No Reason Provided"
+		}
+
+		/** An image that the user wishes to provide for context to the ban. */
+		val image by optionalString {
+			name = "image"
+			description = "The URL to an image you'd like to provide"
 		}
 	}
 
@@ -345,6 +363,12 @@ class TerminalModeration : Extension() {
 			name = "reason"
 			description = "The reason for the ban"
 			defaultValue = "No Reason Provided"
+		}
+
+		/** An image that the user wishes to provide for context to the soft-ban. */
+		val image by optionalString {
+			name = "image"
+			description = "The URL to an image you'd like to provide"
 		}
 	}
 }

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
@@ -320,7 +320,7 @@ class TerminalModeration : Extension() {
 		/** An image that the user wishes to provide for context to the kick. */
 		val image by optionalString {
 			name = "image"
-			description = "The URL to an image you'd like to provide"
+			description = "The URL to an image you'd like to provide as extra context for the action"
 		}
 	}
 
@@ -347,7 +347,7 @@ class TerminalModeration : Extension() {
 		/** An image that the user wishes to provide for context to the ban. */
 		val image by optionalString {
 			name = "image"
-			description = "The URL to an image you'd like to provide"
+			description = "The URL to an image you'd like to provide as extra context for the action"
 		}
 	}
 
@@ -383,7 +383,7 @@ class TerminalModeration : Extension() {
 		/** An image that the user wishes to provide for context to the soft-ban. */
 		val image by optionalString {
 			name = "image"
-			description = "The URL to an image you'd like to provide"
+			description = "The URL to an image you'd like to provide as extra context for the action"
 		}
 	}
 }

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/moderation/TerminalModeration.kt
@@ -63,6 +63,11 @@ class TerminalModeration : Extension() {
 				// Clarify the user is not a bot or moderator
 				isBotOrModerator(userArg, "ban") ?: return@action
 
+				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
+					respond { content = "Invalid Image! Please try again." }
+					return@action
+				}
+
 				// DM the user before the ban task is run, to avoid error, null if fails
 				val dm = userDMEmbed(
 					userArg,
@@ -176,6 +181,11 @@ class TerminalModeration : Extension() {
 
 				isBotOrModerator(userArg, "soft-ban") ?: return@action
 
+				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
+					respond { content = "Invalid Image! Please try again." }
+					return@action
+				}
+
 				// DM the user before the ban task is run
 				val dm = userDMEmbed(
 					userArg,
@@ -250,6 +260,11 @@ class TerminalModeration : Extension() {
 
 				// Clarify the user isn't a bot or a moderator
 				isBotOrModerator(userArg, "kick") ?: return@action
+
+				if (arguments.image != null && !arguments.image!!.contains("http", true)) {
+					respond { content = "Invalid Image! Please try again." }
+					return@action
+				}
 
 				// DM the user about it before the kick
 				val dm = userDMEmbed(

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Constants.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Constants.kt
@@ -18,3 +18,6 @@ val MONGO_URI = envOrNull("MONGO_URI") ?: "mongodb://localhost:27017"
 
 /** Sentry connection DSN. If null, Sentry won't be used. */
 val SENTRY_DSN = envOrNull("SENTRY_DSN")
+
+/** The [String] values required to be present when using an image in an embed. */
+val URL_REQUIREMENTS = listOf("https", "http", ".co", ":", "//")

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Constants.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Constants.kt
@@ -18,6 +18,3 @@ val MONGO_URI = envOrNull("MONGO_URI") ?: "mongodb://localhost:27017"
 
 /** Sentry connection DSN. If null, Sentry won't be used. */
 val SENTRY_DSN = envOrNull("SENTRY_DSN")
-
-/** The [String] values required to be present when using an image in an embed. */
-val URL_REQUIREMENTS = listOf("https", "http", ".co", ":", "//")

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
@@ -78,31 +78,3 @@ suspend fun EphemeralSlashCommandContext<*>.isBotOrModerator(user: User, command
 
 	return "success" // Nothing should be done with the success, checks should be based on if this function returns null
 }
-
-/**
- * This function will check image inputs from commands and verify they contain all the required [String]s to form
- * a good URL, and avoid any KtorRequestExceptions. It uses [String]s from [URL_REQUIREMENTS] and checks them against
- * a provided [imageURL]. The [imageURL] must contain everything in [URL_REQUIREMENTS] or else the function will
- * return null, to allow the command it has been called in to be returned using an elvis.
- *
- * @param imageURL The URL of the image provided
- * @return **null** if the [imageURL] is bad, "success" if the [imageURL] is good
- * @author NoComment1105
- * @since 3.3.0
- */
-suspend fun EphemeralSlashCommandContext<*>.checkImages(imageURL: String?): String? {
-	var success = 0
-
-	for (i in URL_REQUIREMENTS) {
-		if (imageURL != null && imageURL.contains(i, true)) {
-			success++
-		}
-	}
-
-	return if (success != URL_REQUIREMENTS.size) {
-		respond { content = "Invalid Image! Please try again." }
-		null
-	} else {
-		"success"
-	}
-}

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/_Utils.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.toList
  * any one of them is null, we fail with the unable to access config error message.
  *
  * @author NoComment1105
+ * @since 3.2.0
  */
 suspend fun CheckContext<*>.configPresent() {
 	if (!passed) {
@@ -44,6 +45,7 @@ suspend fun CheckContext<*>.configPresent() {
  * @param commandName The name of the command. Used for the responses and error message
  * @return *null*, if user is a bot/moderator. *success* if it isn't
  * @author NoComment1105
+ * @since 2.1.0
  */
 suspend fun EphemeralSlashCommandContext<*>.isBotOrModerator(user: User, commandName: String): String? {
 	val moderatorRoleId = DatabaseHelper.getConfig(guild!!.id)?.moderatorsPing
@@ -75,4 +77,32 @@ suspend fun EphemeralSlashCommandContext<*>.isBotOrModerator(user: User, command
 	}
 
 	return "success" // Nothing should be done with the success, checks should be based on if this function returns null
+}
+
+/**
+ * This function will check image inputs from commands and verify they contain all the required [String]s to form
+ * a good URL, and avoid any KtorRequestExceptions. It uses [String]s from [URL_REQUIREMENTS] and checks them against
+ * a provided [imageURL]. The [imageURL] must contain everything in [URL_REQUIREMENTS] or else the function will
+ * return null, to allow the command it has been called in to be returned using an elvis.
+ *
+ * @param imageURL The URL of the image provided
+ * @return **null** if the [imageURL] is bad, "success" if the [imageURL] is good
+ * @author NoComment1105
+ * @since 3.3.0
+ */
+suspend fun EphemeralSlashCommandContext<*>.checkImages(imageURL: String?): String? {
+	var success = 0
+
+	for (i in URL_REQUIREMENTS) {
+		if (imageURL != null && imageURL.contains(i, true)) {
+			success++
+		}
+	}
+
+	return if (success != URL_REQUIREMENTS.size) {
+		respond { content = "Invalid Image! Please try again." }
+		null
+	} else {
+		"success"
+	}
 }


### PR DESCRIPTION
Does what the title states. You can see an example below
![image](https://user-images.githubusercontent.com/67918617/168403456-793cc5be-d202-4d52-af60-037e1246cf10.png)
