### PR TITLE
Hypothetical fix for public utility commands not adding on join

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
@@ -25,6 +25,7 @@ import net.irisshaders.lilybot.extensions.util.Github
 import net.irisshaders.lilybot.extensions.util.ModUtilities
 import net.irisshaders.lilybot.extensions.util.PublicUtilities
 import net.irisshaders.lilybot.extensions.util.RoleMenu
+import net.irisshaders.lilybot.extensions.util.StartupHooks
 import net.irisshaders.lilybot.extensions.util.Tags
 import net.irisshaders.lilybot.extensions.util.ThreadControl
 import net.irisshaders.lilybot.utils.BOT_TOKEN
@@ -75,6 +76,7 @@ suspend fun main() {
 			add(::PublicUtilities)
 			add(::Report)
 			add(::RoleMenu)
+			add(::StartupHooks)
 			add(::Tags)
 			add(::TemporaryModeration)
 			add(::TerminalModeration)

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/PublicUtilities.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/PublicUtilities.kt
@@ -23,10 +23,7 @@ import dev.kord.rest.builder.message.create.embed
 import dev.kord.rest.builder.message.modify.embed
 import kotlinx.datetime.Clock
 import net.irisshaders.lilybot.utils.DatabaseHelper
-import net.irisshaders.lilybot.utils.ONLINE_STATUS_CHANNEL
-import net.irisshaders.lilybot.utils.TEST_GUILD_ID
 import net.irisshaders.lilybot.utils.configPresent
-import net.irisshaders.lilybot.utils.responseEmbedInChannel
 import net.irisshaders.lilybot.utils.userDMEmbed
 
 /**
@@ -39,34 +36,6 @@ class PublicUtilities : Extension() {
 	override val name = "public-utilities"
 
 	override suspend fun setup() {
-		/**
-		 * Online notification, that is printed to the official [TEST_GUILD_ID]'s [ONLINE_STATUS_CHANNEL].
-		 * @author IMS212
-		 * @since v2.0
-		 */
-		// The channel specifically for sending online notifications to
-		val onlineLog = kord.getGuild(TEST_GUILD_ID)?.getChannel(ONLINE_STATUS_CHANNEL) as GuildMessageChannelBehavior
-		responseEmbedInChannel(
-			onlineLog, "Lily is now online!", null, DISCORD_GREEN, null
-		)
-
-		/**
-		 * This function is called to remove any threads in the database that haven't had a message sent in the last
-		 * week. It only runs on startup.
-		 * @author tempest15
-		 * @since 3.2.0
-		 */
-		DatabaseHelper.cleanupThreadData(kord)
-
-		/**
-		 * This function is called to remove any guilds in the database that haven't had Lily in them for more than
-		 * a month. It only runs on startup
-		 *
-		 * @author NoComment1105
-		 * @since 3.2.0
-		 */
-		DatabaseHelper.cleanupGuildData()
-
 		/**
 		 * Ping Command.
 		 * @author IMS212

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/StartupHooks.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/StartupHooks.kt
@@ -1,0 +1,51 @@
+package net.irisshaders.lilybot.extensions.util
+
+import com.kotlindiscord.kord.extensions.DISCORD_GREEN
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
+import net.irisshaders.lilybot.utils.DatabaseHelper
+import net.irisshaders.lilybot.utils.ONLINE_STATUS_CHANNEL
+import net.irisshaders.lilybot.utils.TEST_GUILD_ID
+import net.irisshaders.lilybot.utils.responseEmbedInChannel
+
+/**
+ * This class serves as a place for all functions that get run on bot start and bot start alone. This *hypothetically*
+ * fixes a peculiar bug with [PublicUtilities], where if these functions we're present within, all other feature from
+ * the class don't get added to a server when the bot joins the server, and instead only present themselves after a
+ * bot instance restart.
+ *
+ * @since 3.3.0
+ */
+class StartupHooks : Extension() {
+	override val name = "startuphooks"
+
+	override suspend fun setup() {
+		/**
+		 * Online notification, that is printed to the official [TEST_GUILD_ID]'s [ONLINE_STATUS_CHANNEL].
+		 * @author IMS212
+		 * @since v2.0
+		 */
+		// The channel specifically for sending online notifications to
+		val onlineLog = kord.getGuild(TEST_GUILD_ID)?.getChannel(ONLINE_STATUS_CHANNEL) as GuildMessageChannelBehavior
+		responseEmbedInChannel(
+			onlineLog, "Lily is now online!", null, DISCORD_GREEN, null
+		)
+
+		/**
+		 * This function is called to remove any threads in the database that haven't had a message sent in the last
+		 * week. It only runs on startup.
+		 * @author tempest15
+		 * @since 3.2.0
+		 */
+		DatabaseHelper.cleanupThreadData(kord)
+
+		/**
+		 * This function is called to remove any guilds in the database that haven't had Lily in them for more than
+		 * a month. It only runs on startup
+		 *
+		 * @author NoComment1105
+		 * @since 3.2.0
+		 */
+		DatabaseHelper.cleanupGuildData()
+	}
+}


### PR DESCRIPTION
Currently there is a strange bug in production where the entirety of the `PublicUtilities` class stuff doesn't get applied to a server when Lily joins. I have only been able to reproduce it once with production and not in dev. This changes makes the most logical sense to me, splitting down startup things into their own class and leaving actual public utilities in their class