### PR TITLE
Get channel default archive times

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
@@ -98,10 +98,12 @@ class ThreadInviter : Extension() {
 					response.delete(10000L, false)
 				} else {
 					val thread =
+						// Create a thread with the message sent, title it with the users tag and set the archive
+						// duration to the channels settings. If they're null, set it to one day
 						textChannel.startPublicThreadWithMessage(
 							event.message.id,
 							"Support thread for " + event.member!!.asUser().username,
-							ArchiveDuration.Hour
+							event.message.getChannel().data.defaultAutoArchiveDuration.value ?: ArchiveDuration.Day
 						)
 
 					DatabaseHelper.setThreadOwner(thread.id, event.member!!.id)


### PR DESCRIPTION
For some reason, although Discord may say in the channel menu that the duration is set, it's often not, meaning the default duration can be null. Channels that want support a different time will set this specifically, so we can set to the Discord default duration, when defaultAutoArchiveDuration is null

Fixes #141 