### PR TITLE
Add commands to make a channel "image only"

### DIFF
--- a/docs/commanddocs.toml
+++ b/docs/commanddocs.toml
@@ -194,3 +194,21 @@ category = "Tag commands"
 name = "tag-help"
 args = "none"
 result = "Displays a help command with all this information, in greater detail."
+
+[[command]]
+category = "Gallery channel commands"
+name = "gallery-channel set"
+args = "none"
+result = "Sets the channel you are in a Gallery channel"
+
+[[command]]
+category = "Gallery channel commands"
+name = "gallery-channel unset"
+args = "none"
+result = "Unsets the channel you are in a Gallery channel"
+
+[[command]]
+category = "Gallery channel commands"
+name = "gallery-channel list"
+args = "none"
+result = "Displays an embed of the image channels for the current guild"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -287,3 +287,21 @@ nickname change permissions on users
 Name: `nickname clear`
 
 Result: Clears the nickname of the user that ran the command
+
+## Gallery Channels
+Gallery channel commands are for setting a channel to be image/attachment/embed only.
+
+### Set
+Name: `gallery-channel set`
+
+Result: Sets the channel you are in as a Gallery channel
+
+### Unset
+Name: `gallery-channel unset`
+
+Result: Unsets the gallery channel you are in
+
+### List
+Name: `gallery-channel list`
+
+Result: Displays an embed of the image channels for the current guild

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -394,21 +394,39 @@ none
 
 ---
 
+### Name: `gallery-channel set`
+**Arguments**:
+none
 
-## Gallery Channels
-Gallery channel commands are for setting a channel to be image/attachment/embed only.
+**Result**: Sets the channel you are in a Gallery channel
 
-### Set
-Name: `gallery-channel set`
+**Required Permissions**: `none`
 
-Result: Sets the channel you are in as a Gallery channel
+**Command category**: `Gallery channel commands`
 
-### Unset
-Name: `gallery-channel unset`
+---
 
-Result: Unsets the gallery channel you are in
+### Name: `gallery-channel unset`
+**Arguments**:
+none
 
-### List
-Name: `gallery-channel list`
+**Result**: Unsets the channel you are in a Gallery channel
 
-Result: Displays an embed of the image channels for the current guild
+**Required Permissions**: `none`
+
+**Command category**: `Gallery channel commands`
+
+---
+
+### Name: `gallery-channel list`
+**Arguments**:
+none
+
+**Result**: Displays an embed of the image channels for the current guild
+
+**Required Permissions**: `none`
+
+**Command category**: `Gallery channel commands`
+
+---
+

--- a/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
@@ -22,6 +22,7 @@ import net.irisshaders.lilybot.extensions.moderation.Report
 import net.irisshaders.lilybot.extensions.moderation.TemporaryModeration
 import net.irisshaders.lilybot.extensions.moderation.TerminalModeration
 import net.irisshaders.lilybot.extensions.util.Github
+import net.irisshaders.lilybot.extensions.util.ImageChannel
 import net.irisshaders.lilybot.extensions.util.ModUtilities
 import net.irisshaders.lilybot.extensions.util.PublicUtilities
 import net.irisshaders.lilybot.extensions.util.RoleMenu
@@ -68,6 +69,7 @@ suspend fun main() {
 		extensions {
 			add(::Config)
 			add(::Github)
+			add(::ImageChannel)
 			add(::JoinLeaveDetection)
 			add(::LogUploading)
 			add(::MemberJoinLeave)

--- a/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/LilyBot.kt
@@ -21,8 +21,8 @@ import net.irisshaders.lilybot.extensions.events.ThreadInviter
 import net.irisshaders.lilybot.extensions.moderation.Report
 import net.irisshaders.lilybot.extensions.moderation.TemporaryModeration
 import net.irisshaders.lilybot.extensions.moderation.TerminalModeration
+import net.irisshaders.lilybot.extensions.util.GalleryChannel
 import net.irisshaders.lilybot.extensions.util.Github
-import net.irisshaders.lilybot.extensions.util.ImageChannel
 import net.irisshaders.lilybot.extensions.util.ModUtilities
 import net.irisshaders.lilybot.extensions.util.PublicUtilities
 import net.irisshaders.lilybot.extensions.util.RoleMenu
@@ -69,7 +69,7 @@ suspend fun main() {
 		extensions {
 			add(::Config)
 			add(::Github)
-			add(::ImageChannel)
+			add(::GalleryChannel)
 			add(::JoinLeaveDetection)
 			add(::LogUploading)
 			add(::MemberJoinLeave)

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/GalleryChannel.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/GalleryChannel.kt
@@ -17,35 +17,35 @@ import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.rest.builder.message.create.embed
 import kotlinx.coroutines.delay
-import net.irisshaders.lilybot.utils.DatabaseHelper.deleteImageChannel
-import net.irisshaders.lilybot.utils.DatabaseHelper.getImageChannels
-import net.irisshaders.lilybot.utils.DatabaseHelper.setImageChannel
+import net.irisshaders.lilybot.utils.DatabaseHelper.deleteGalleryChannel
+import net.irisshaders.lilybot.utils.DatabaseHelper.getGalleryChannels
+import net.irisshaders.lilybot.utils.DatabaseHelper.setGalleryChannel
 import net.irisshaders.lilybot.utils.configPresent
 
 /**
- * The class the holds the systems that allow a guild to set a channel as image only.
+ * The class the holds the systems that allow a guild to set a channel as a gallery channel.
  *
  * @since 3.3.0
  */
-class ImageChannel : Extension() {
-	override val name = "imagechannel"
+class GalleryChannel : Extension() {
+	override val name = "gallery-channel"
 
 	override suspend fun setup() {
 		/**
-		 * Image channel commands.
+		 * gallery channel commands.
 		 * @author NoComment1105
 		 * @since 3.3.0
 		 */
 		ephemeralSlashCommand {
-			name = "image-channel"
+			name = "gallery-channel"
 			description = "The parent command for image channel setting"
 
 			/**
-			 * The command that sets the image channel.
+			 * The command that sets the gallery channel.
 			 */
 			ephemeralSubCommand {
 				name = "set"
-				description = "Set a channel as an image channel"
+				description = "Set a channel as a gallery channel"
 
 				check {
 					anyGuild()
@@ -54,20 +54,20 @@ class ImageChannel : Extension() {
 				}
 
 				action {
-					setImageChannel(guild!!.id, channel.asChannel().id)
+					setGalleryChannel(guild!!.id, channel.asChannel().id)
 
 					respond {
-						content = "Set channel as image only"
+						content = "Set channel as gallery channel"
 					}
 				}
 			}
 
 			/**
-			 * The command that unsets the image channel.
+			 * The command that unsets the gallery channel.
 			 */
 			ephemeralSubCommand {
 				name = "unset"
-				description = "Unset a channel as an image channel"
+				description = "Unset a channel as a gallery channel"
 
 				check {
 					anyGuild()
@@ -76,10 +76,10 @@ class ImageChannel : Extension() {
 				}
 
 				action {
-					deleteImageChannel(guild!!.id, channel.asChannel().id)
+					deleteGalleryChannel(guild!!.id, channel.asChannel().id)
 
 					respond {
-						content = "Unset channel as image only"
+						content = "Unset channel as gallery channel"
 					}
 				}
 			}
@@ -89,14 +89,14 @@ class ImageChannel : Extension() {
 			 */
 			ephemeralSubCommand {
 				name = "list"
-				description = "List all image channels in the guild"
+				description = "List all gallery channels in the guild"
 
 				check {
 					anyGuild()
 				}
 
 				action {
-					val imageChannels = getImageChannels(guild!!.id)
+					val imageChannels = getGalleryChannels(guild!!.id)
 					var channels = ""
 
 					imageChannels.forEach {
@@ -105,8 +105,8 @@ class ImageChannel : Extension() {
 
 					respond {
 						embed {
-							title = "Image channels"
-							description = "Here are the image only channels in this guild."
+							title = "Gallery channels"
+							description = "Here are the gallery channels in this guild."
 							field {
 								name = "Channels:"
 								value = if (channels != "") channels.replace(" ", "\n") else "No channels found!"
@@ -128,7 +128,7 @@ class ImageChannel : Extension() {
 			}
 
 			action {
-				val imageChannels = getImageChannels(guildFor(event)!!.id)
+				val imageChannels = getGalleryChannels(guildFor(event)!!.id)
 
 				for (i in imageChannels) {
 					// If there are no attachments to the message and the channel we're in is an image channel

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ImageChannel.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ImageChannel.kt
@@ -1,0 +1,92 @@
+package net.irisshaders.lilybot.extensions.util
+
+import com.kotlindiscord.kord.extensions.checks.anyGuild
+import com.kotlindiscord.kord.extensions.checks.hasPermission
+import com.kotlindiscord.kord.extensions.commands.application.slash.ephemeralSubCommand
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
+import com.kotlindiscord.kord.extensions.types.respond
+import dev.kord.common.entity.Permission
+import dev.kord.rest.builder.message.create.embed
+import net.irisshaders.lilybot.utils.DatabaseHelper.deleteImageChannel
+import net.irisshaders.lilybot.utils.DatabaseHelper.getImageChannels
+import net.irisshaders.lilybot.utils.DatabaseHelper.setImageChannel
+import net.irisshaders.lilybot.utils.configPresent
+
+class ImageChannel : Extension() {
+	override val name = "imagechannel"
+
+	override suspend fun setup() {
+		ephemeralSlashCommand {
+			name = "image-channel"
+			description = "The parent command for image channel setting"
+
+			ephemeralSubCommand {
+				name = "set"
+				description = "Set a channel as an image channel"
+
+				check {
+					anyGuild()
+					configPresent()
+					hasPermission(Permission.ManageGuild)
+				}
+
+				action {
+					setImageChannel(guild!!.id, channel.asChannel().id)
+
+					respond {
+						content = "Set channel as image only"
+					}
+				}
+			}
+
+			ephemeralSubCommand {
+				name = "unset"
+				description = "Unset a channel as an image channel"
+
+				check {
+					anyGuild()
+					configPresent()
+					hasPermission(Permission.ManageGuild)
+				}
+
+				action {
+					deleteImageChannel(guild!!.id, channel.asChannel().id)
+
+					respond {
+						content = "Unset channel as image only"
+					}
+				}
+			}
+
+			ephemeralSubCommand {
+				name = "list"
+				description = "List all image channels in the guild"
+
+				check {
+					anyGuild()
+				}
+
+				action {
+					val imageChannels = getImageChannels(guild!!.id)
+					var channels = ""
+
+					imageChannels.forEach {
+						channels += "<#${it.channelId}> "
+					}
+
+					respond {
+						embed {
+							title = "Image channels"
+							description = "Here are the image only channels in this guild."
+							field {
+								name = "Channels:"
+								value = if (channels != "") channels.replace(" ", "\n") else "No channels found!"
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ImageChannel.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/ImageChannel.kt
@@ -1,26 +1,48 @@
 package net.irisshaders.lilybot.extensions.util
 
 import com.kotlindiscord.kord.extensions.checks.anyGuild
+import com.kotlindiscord.kord.extensions.checks.guildFor
 import com.kotlindiscord.kord.extensions.checks.hasPermission
 import com.kotlindiscord.kord.extensions.commands.application.slash.ephemeralSubCommand
 import com.kotlindiscord.kord.extensions.extensions.Extension
 import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
+import com.kotlindiscord.kord.extensions.extensions.event
 import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.utils.delete
+import com.kotlindiscord.kord.extensions.utils.isNullOrBot
+import com.kotlindiscord.kord.extensions.utils.respond
+import com.soywiz.klock.seconds
 import dev.kord.common.entity.Permission
+import dev.kord.core.event.message.MessageCreateEvent
+import dev.kord.core.exception.EntityNotFoundException
 import dev.kord.rest.builder.message.create.embed
+import kotlinx.coroutines.delay
 import net.irisshaders.lilybot.utils.DatabaseHelper.deleteImageChannel
 import net.irisshaders.lilybot.utils.DatabaseHelper.getImageChannels
 import net.irisshaders.lilybot.utils.DatabaseHelper.setImageChannel
 import net.irisshaders.lilybot.utils.configPresent
 
+/**
+ * The class the holds the systems that allow a guild to set a channel as image only.
+ *
+ * @since 3.3.0
+ */
 class ImageChannel : Extension() {
 	override val name = "imagechannel"
 
 	override suspend fun setup() {
+		/**
+		 * Image channel commands.
+		 * @author NoComment1105
+		 * @since 3.3.0
+		 */
 		ephemeralSlashCommand {
 			name = "image-channel"
 			description = "The parent command for image channel setting"
 
+			/**
+			 * The command that sets the image channel.
+			 */
 			ephemeralSubCommand {
 				name = "set"
 				description = "Set a channel as an image channel"
@@ -40,6 +62,9 @@ class ImageChannel : Extension() {
 				}
 			}
 
+			/**
+			 * The command that unsets the image channel.
+			 */
 			ephemeralSubCommand {
 				name = "unset"
 				description = "Unset a channel as an image channel"
@@ -59,6 +84,9 @@ class ImageChannel : Extension() {
 				}
 			}
 
+			/**
+			 * The command that returns a list of all image channels for a particular guild.
+			 */
 			ephemeralSubCommand {
 				name = "list"
 				description = "List all image channels in the guild"
@@ -82,6 +110,45 @@ class ImageChannel : Extension() {
 							field {
 								name = "Channels:"
 								value = if (channels != "") channels.replace(" ", "\n") else "No channels found!"
+							}
+						}
+					}
+				}
+			}
+		}
+
+		/**
+		 * The event for checking a channel.
+		 * @since 3.3.0
+		 */
+		event<MessageCreateEvent> {
+			check {
+				anyGuild()
+				failIf { event.message.author.isNullOrBot() } // Fail if null in case an ephemeral message is created
+			}
+
+			action {
+				val imageChannels = getImageChannels(guildFor(event)!!.id)
+
+				for (i in imageChannels) {
+					// If there are no attachments to the message and the channel we're in is an image channel
+					if (event.message.channelId == i.channelId && event.message.attachments.isEmpty()) {
+						// We delay to give the message a chance to populate with an embed, if it is a link to imgur etc.
+						delay(0.1.seconds.millisecondsLong)
+						if (event.message.embeds.isEmpty()) { // If there is still no embed, we delete the message
+							// and explain why
+							val response = event.message.respond {
+								content = "This channel is for images only!"
+							}
+
+							event.message.delete()
+
+							try {
+								// Delete the explanation after 3 seconds. If an exception is thrown, the
+								// message has already been deleted
+								response.delete(3.seconds.millisecondsLong)
+							} catch (e: EntityNotFoundException) {
+								// The message that we're attempting to delete has already been deleted.
 							}
 						}
 					}

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -364,6 +364,21 @@ object DatabaseHelper {
 
 		databaseLogger.info("Deleted old data for $deletedGuildData guilds from the database")
 	}
+
+	suspend fun setImageChannel(inputGuildId: Snowflake, inputChannelId: Snowflake) {
+		val collection = database.getCollection<ImageChannelData>()
+		collection.insertOne(ImageChannelData(inputGuildId, inputChannelId))
+	}
+
+	suspend fun deleteImageChannel(inputGuildId: Snowflake, inputChannelId: Snowflake) {
+		val collection = database.getCollection<ImageChannelData>()
+		collection.deleteOne(ImageChannelData::channelId eq inputChannelId, ImageChannelData::guildId eq inputGuildId)
+	}
+
+	suspend fun getImageChannels(inputGuildId: Snowflake): List<ImageChannelData> {
+		val collection = database.getCollection<ImageChannelData>()
+		return collection.find(ImageChannelData::guildId eq inputGuildId).toList()
+	}
 }
 
 /**
@@ -473,4 +488,10 @@ data class ThreadData(
 data class GuildLeaveTimeData(
 	val guildId: Snowflake,
 	val guildLeaveTime: Instant
+)
+
+@Serializable
+data class ImageChannelData(
+	val guildId: Snowflake,
+	val channelId: Snowflake
 )

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -9,6 +9,7 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import mu.KotlinLogging
 import net.irisshaders.lilybot.database
+import org.litote.kmongo.coroutine.CoroutineCollection
 import org.litote.kmongo.eq
 
 /**
@@ -393,17 +394,13 @@ object DatabaseHelper {
 	}
 
 	/**
-	 * Collects every gallery channel for the [inputGuildId] into a [List].
+	 * Collects every gallery channel in the database into a [List].
 	 *
-	 * @param inputGuildId The guild that image channels are being gotten for
-	 * @return A [List] of all the gallery channels in the guild
+	 * @return The [CoroutineCollection] of [GalleryChannelData] for all the gallery channels in the database
 	 * @author NoComment1105
 	 * @since 3.3.0
 	 */
-	suspend fun getGalleryChannels(inputGuildId: Snowflake): List<GalleryChannelData> {
-		val collection = database.getCollection<GalleryChannelData>()
-		return collection.find(GalleryChannelData::guildId eq inputGuildId).toList()
-	}
+	fun getGalleryChannels(): CoroutineCollection<GalleryChannelData> = database.getCollection()
 }
 
 /**

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -370,39 +370,39 @@ object DatabaseHelper {
 	 * the channel later.
 	 *
 	 * @param inputGuildId The guild the channel is in
-	 * @param inputChannelId The channel that is being set as image only
+	 * @param inputChannelId The channel that is being set as a gallery channel
 	 * @author NoComment1105
 	 * @since 3.3.0
 	 */
-	suspend fun setImageChannel(inputGuildId: Snowflake, inputChannelId: Snowflake) {
-		val collection = database.getCollection<ImageChannelData>()
-		collection.insertOne(ImageChannelData(inputGuildId, inputChannelId))
+	suspend fun setGalleryChannel(inputGuildId: Snowflake, inputChannelId: Snowflake) {
+		val collection = database.getCollection<GalleryChannelData>()
+		collection.insertOne(GalleryChannelData(inputGuildId, inputChannelId))
 	}
 
 	/**
-	 * Removes a channel ID from the image channel database.
+	 * Removes a channel ID from the gallery channel database.
 	 *
 	 * @param inputGuildId The guild the channel is in
 	 * @param inputChannelId The channel being removed
 	 * @author NoComment1105
 	 * @since 3.3.0
 	 */
-	suspend fun deleteImageChannel(inputGuildId: Snowflake, inputChannelId: Snowflake) {
-		val collection = database.getCollection<ImageChannelData>()
-		collection.deleteOne(ImageChannelData::channelId eq inputChannelId, ImageChannelData::guildId eq inputGuildId)
+	suspend fun deleteGalleryChannel(inputGuildId: Snowflake, inputChannelId: Snowflake) {
+		val collection = database.getCollection<GalleryChannelData>()
+		collection.deleteOne(GalleryChannelData::channelId eq inputChannelId, GalleryChannelData::guildId eq inputGuildId)
 	}
 
 	/**
-	 * Collects every image channel for the [inputGuildId] into a [List].
+	 * Collects every gallery channel for the [inputGuildId] into a [List].
 	 *
 	 * @param inputGuildId The guild that image channels are being gotten for
-	 * @return A [List] of all the image channels in the guild
+	 * @return A [List] of all the gallery channels in the guild
 	 * @author NoComment1105
 	 * @since 3.3.0
 	 */
-	suspend fun getImageChannels(inputGuildId: Snowflake): List<ImageChannelData> {
-		val collection = database.getCollection<ImageChannelData>()
-		return collection.find(ImageChannelData::guildId eq inputGuildId).toList()
+	suspend fun getGalleryChannels(inputGuildId: Snowflake): List<GalleryChannelData> {
+		val collection = database.getCollection<GalleryChannelData>()
+		return collection.find(GalleryChannelData::guildId eq inputGuildId).toList()
 	}
 }
 
@@ -523,7 +523,7 @@ data class GuildLeaveTimeData(
  * @since 3.3.0
  */
 @Serializable
-data class ImageChannelData(
+data class GalleryChannelData(
 	val guildId: Snowflake,
 	val channelId: Snowflake
 )

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -365,16 +365,41 @@ object DatabaseHelper {
 		databaseLogger.info("Deleted old data for $deletedGuildData guilds from the database")
 	}
 
+	/**
+	 * Stores a channel ID as input by the user, in the database, with it's corresponding guild, allowing us to find
+	 * the channel later.
+	 *
+	 * @param inputGuildId The guild the channel is in
+	 * @param inputChannelId The channel that is being set as image only
+	 * @author NoComment1105
+	 * @since 3.3.0
+	 */
 	suspend fun setImageChannel(inputGuildId: Snowflake, inputChannelId: Snowflake) {
 		val collection = database.getCollection<ImageChannelData>()
 		collection.insertOne(ImageChannelData(inputGuildId, inputChannelId))
 	}
 
+	/**
+	 * Removes a channel ID from the image channel database.
+	 *
+	 * @param inputGuildId The guild the channel is in
+	 * @param inputChannelId The channel being removed
+	 * @author NoComment1105
+	 * @since 3.3.0
+	 */
 	suspend fun deleteImageChannel(inputGuildId: Snowflake, inputChannelId: Snowflake) {
 		val collection = database.getCollection<ImageChannelData>()
 		collection.deleteOne(ImageChannelData::channelId eq inputChannelId, ImageChannelData::guildId eq inputGuildId)
 	}
 
+	/**
+	 * Collects every image channel for the [inputGuildId] into a [List].
+	 *
+	 * @param inputGuildId The guild that image channels are being gotten for
+	 * @return A [List] of all the image channels in the guild
+	 * @author NoComment1105
+	 * @since 3.3.0
+	 */
 	suspend fun getImageChannels(inputGuildId: Snowflake): List<ImageChannelData> {
 		val collection = database.getCollection<ImageChannelData>()
 		return collection.find(ImageChannelData::guildId eq inputGuildId).toList()
@@ -490,6 +515,13 @@ data class GuildLeaveTimeData(
 	val guildLeaveTime: Instant
 )
 
+/**
+ * The data for image channels in a guild.
+ *
+ * @param guildId The ID of the guild the image channel is for
+ * @param channelId The ID of the image channel being set
+ * @since 3.3.0
+ */
 @Serializable
 data class ImageChannelData(
 	val guildId: Snowflake,


### PR DESCRIPTION
This feature will set up a channel to only allow messages that contain attachments or embeds. If the message does not, it will delete it and notify the user, before deleting the notification.