### PR TITLE
Support PluralKit with message deletions

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
@@ -1,0 +1,101 @@
+package net.irisshaders.lilybot.api.pluralkit
+
+import dev.kord.common.entity.Snowflake
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.http.ContentType
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * The URL of the [PluralKit API](https://pluralkit.me/api), which can be used for accessing other parts of the api
+ * without typing out duplicating the main URL.
+ */
+internal const val PK_API_URL = "https://api.pluralkit.me/v2"
+
+/** The URL of messages from the [PluralKit API](https://pluralkit.me/api). */
+internal const val MESSAGE_URL = "$PK_API_URL/messages/{id}"
+
+class PluralKit {
+
+	/** The client used for querying values from the API. */
+	private val client = HttpClient {
+		install(ContentNegotiation) {
+			json(
+				Json { ignoreUnknownKeys = true },
+				ContentType.Any
+			)
+		}
+
+		expectSuccess = true
+	}
+
+	/**
+	 * Using a provided message [Snowflake], we call [checkIfProxied] to find out if the message was proxied or not.
+	 *
+	 * @param id The ID of the message being checked
+	 * @see checkIfProxied
+	 * @return True if proxied, false if not
+	 * @author NoComment1105
+	 * @since 3.3.0
+	 */
+	suspend fun checkIfProxied(id: Snowflake) = checkIfProxied(id.toString())
+
+	/**
+	 * Using a provided message ID, we check against the [PluralKit API](https://pluralkit.me/api/) to find out if
+	 * the message has been proxied. If it has been, we'll return true on the function, allowing this to be checked in
+	 * for in other places in the bot. If getting the message returns an error response in the range of 400 to 600, we
+	 * return false, as the message has not been proxied.
+	 *
+	 * @param id The ID of the message being checked as a string
+	 * @return True if proxied, false if not
+	 * @see checkIfProxied
+	 * @author NoComment1105
+	 * @since 3.3.0
+	 */
+	private suspend fun checkIfProxied(id: String): Boolean {
+		val url = MESSAGE_URL.replace("{id}", id)
+
+		var proxied: Boolean? = null
+
+		try {
+			client.get(url).body<PluralKitMessage>()
+
+			proxied = true
+		} catch (e: ClientRequestException) {
+			if (e.response.status.value in 400 until 600) {
+				proxied = false
+			}
+		}
+
+		return proxied!!
+	}
+}
+
+/**
+ * This is the data class for a PluralKit message, as per the documentation on the
+ * [PluralKit Docs site](https://pluralkit.me/api/models/#message-model). It is missing the System and Member objects
+ * currently (31st May), since for the use case above, they're not fully required.
+ *
+ * **NOTE:** All values are encoded as a string by the api for precision reasons.
+ *
+ * @param timestamp The time the message was sent
+ * @param id The ID of the message sent by the webhook
+ * @param original The ID of the (now-deleted) message that triggered the proxy
+ * @param channel The ID of the channel the message was sent in
+ * @param guild The ID of the server the message was sent in
+ * @since 3.3.0
+ */
+@Serializable
+data class PluralKitMessage(
+	val timestamp: Instant,
+	val id: Snowflake,
+	val original: Snowflake,
+	val channel: Snowflake,
+	val guild: Snowflake
+)

--- a/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
@@ -21,7 +21,7 @@ internal const val PK_API_URL = "https://api.pluralkit.me/v2"
 /** The URL of messages from the [PluralKit API](https://pluralkit.me/api). */
 internal const val MESSAGE_URL = "$PK_API_URL/messages/{id}"
 
-class PluralKit {
+object PluralKit {
 
 	/** The client used for querying values from the API. */
 	private val client = HttpClient {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
@@ -52,7 +52,7 @@ class MessageDelete : Extension() {
 				val messageLocation = event.channel.id.value
 
 				// Avoid logging messages proxied by PluralKit, since these messages aren't "actually deleted"
-				if (PluralKit().checkIfProxied(eventMessage!!.id)) {
+				if (PluralKit.checkIfProxied(eventMessage!!.id)) {
 					return@action
 				}
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
@@ -8,6 +8,7 @@ import dev.kord.core.behavior.channel.GuildMessageChannelBehavior
 import dev.kord.core.behavior.channel.createEmbed
 import dev.kord.core.event.message.MessageDeleteEvent
 import kotlinx.datetime.Clock
+import net.irisshaders.lilybot.api.pluralkit.PluralKit
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.configPresent
 
@@ -50,6 +51,11 @@ class MessageDelete : Extension() {
 				}
 				val messageLocation = event.channel.id.value
 
+				// Avoid logging messages proxied by PluralKit, since these messages aren't "actually deleted"
+				if (PluralKit().checkIfProxied(eventMessage!!.id)) {
+					return@action
+				}
+
 				messageLog.createEmbed {
 					color = DISCORD_PINK
 					title = "Message Deleted"
@@ -63,7 +69,7 @@ class MessageDelete : Extension() {
 						inline = false
 					}
 					// If the message has an attachment, add the link to it to the embed
-					if (eventMessage?.attachments != null && eventMessage.attachments.isNotEmpty()) {
+					if (eventMessage.attachments.isNotEmpty()) {
 						val attachmentUrls = StringBuilder()
 						for (attachment in eventMessage.attachments) {
 							attachmentUrls.append(
@@ -81,12 +87,12 @@ class MessageDelete : Extension() {
 					}
 					field {
 						name = "Message Author:"
-						value = eventMessage?.author?.tag.toString()
+						value = eventMessage.author?.tag.toString()
 						inline = true
 					}
 					field {
 						name = "Author ID:"
-						value = eventMessage?.author?.id.toString()
+						value = eventMessage.author?.id.toString()
 						inline = true
 					}
 				}


### PR DESCRIPTION
By making use of the [PluralKit API](https://pluralkit.me/api), this PR allows us to check if a message that has been deleted, was deleted because it was proxied by PluralKit. It makes use of checking the API using the deleted message ID, and checking if the message does not return an error code from the API. If it does return an error, it's not present in the API and as such not proxied, so we proceed with the deletion.

This is a new branch type (support/**) so the FCP duration is not certain, and up to the development team.