### PR TITLE
Support PluralKit in support threads

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
@@ -36,28 +36,6 @@ object PluralKit {
 	}
 
 	/**
-	 * Using a provided message [Snowflake], we call [checkIfProxied] to find out if the message was proxied or not.
-	 *
-	 * @param id The ID of the message being checked
-	 * @see checkIfProxied
-	 * @return True if proxied, false if not
-	 * @author NoComment1105
-	 * @since 3.3.0
-	 */
-	suspend fun checkIfProxied(id: Snowflake) = checkIfProxied(id.toString())
-
-	/**
-	 * Using a provided message ID, we call [getProxiedMessageAuthorId] to find out the author of the message.
-	 *
-	 * @param id The ID of the message being checked
-	 * @return The ID of the message author or null
-	 * @see getProxiedMessageAuthorId
-	 * @author NoComment1105
-	 * @since 3.3.2
-	 */
-	suspend fun getProxiedMessageAuthorId(id: Snowflake) = getProxiedMessageAuthorId(id.toString())
-
-	/**
 	 * Using a provided message ID, we check against the [PluralKit API](https://pluralkit.me/api/) to find out if
 	 * the message has been proxied. If it has been, we'll return true on the function, allowing this to be checked in
 	 * for in other places in the bot. If getting the message returns an error response in the range of 400 to 600, we
@@ -69,8 +47,8 @@ object PluralKit {
 	 * @author NoComment1105
 	 * @since 3.3.0
 	 */
-	private suspend fun checkIfProxied(id: String): Boolean {
-		val url = MESSAGE_URL.replace("{id}", id)
+	 suspend fun checkIfProxied(id: Snowflake): Boolean {
+		val url = MESSAGE_URL.replace("{id}", id.toString())
 
 		var proxied = false
 
@@ -97,8 +75,8 @@ object PluralKit {
 	 * @author NoComment1105
 	 * @since 3.3.2
 	 */
-	private suspend fun getProxiedMessageAuthorId(id: String): Snowflake? {
-		val url = MESSAGE_URL.replace("{id}", id)
+	 suspend fun getProxiedMessageAuthorId(id: Snowflake): Snowflake? {
+		val url = MESSAGE_URL.replace("{id}", id.toString())
 
 		var authorId: Snowflake? = null
 

--- a/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
@@ -46,6 +46,15 @@ object PluralKit {
 	 */
 	suspend fun checkIfProxied(id: Snowflake) = checkIfProxied(id.toString())
 
+	/**
+	 * Using a provided message ID, we call [getProxiedMessageAuthorId] to find out the author of the message.
+	 *
+	 * @param id The ID of the message being checked
+	 * @return The ID of the message author or null
+	 * @see getProxiedMessageAuthorId
+	 * @author NoComment1105
+	 * @since 3.3.2
+	 */
 	suspend fun getProxiedMessageAuthorId(id: Snowflake) = getProxiedMessageAuthorId(id.toString())
 
 	/**
@@ -78,22 +87,32 @@ object PluralKit {
 		return proxied
 	}
 
+	/**
+	 * Using a provided message ID, we check against the [PluralKit API](https://pluralkit.me/api/) to find out the
+	 * author of the proxied message. If there is no found author, we return null, or the [Snowflake] ID of the author.
+	 *
+	 * @param id The ID of the message being checked as a string
+	 * @return The ID of the message author or null
+	 * @see getProxiedMessageAuthorId
+	 * @author NoComment1105
+	 * @since 3.3.2
+	 */
 	private suspend fun getProxiedMessageAuthorId(id: String): Snowflake? {
 		val url = MESSAGE_URL.replace("{id}", id)
 
-		var author: Snowflake? = null
+		var authorId: Snowflake? = null
 
 		try {
 			val message: PluralKitMessage = client.get(url).body()
 
-			author = message.sender
+			authorId = message.sender
 		} catch (e: ClientRequestException) {
 			if (e.response.status.value !in 200 until 300) {
-				author = null
+				authorId = null
 			}
 		}
 
-		return author
+		return authorId
 	}
 }
 


### PR DESCRIPTION
When a PluralKit user sends a message in a support channel, currently we just choke and die with an error due to being unable to store it. Now, we test the the sender to see if they're not a bot and if the message was proxied and as such return to avoid causing errors. If the user is a bot, we proceed as normal, but get the proxied message author id from the API, to use that as the ID, effectively keeping all original functionality.