### PR TITLE
Reminder improvements

### DIFF
--- a/docs/commanddocs.toml
+++ b/docs/commanddocs.toml
@@ -61,7 +61,7 @@ permissions = "Ban Members"
 category = "Moderation commands"
 name = "warn"
 args = "* `warnUser` - Person to warn - User\n* `reason` - Reason for warn - Optional String\n* `image` - The URL to an image to provide extra context for the action - Optional String"
-result = "Warns `warnUser` with a DM and adds a strike to their points total. Depending on their new points total, action is taken based on the below table.\n\n| Points |     Sanction     |\n|:------:|:----------------:|\n|   1    | None.            |\n|   2    | 3 hour timeout.  |\n|   3    | 12 hour timeout. |\n|   3+   | 3 day timeout.   |"
+result = "Warns `warnUser` with a DM and adds a strike to their points total. Depending on their new points total, action is taken based on the below table.\n\n| Points |     Sanction     |\n|:------:|:----------------:|\n|   1    |      None.       |\n|   2    | 3 hour timeout.  |\n|   3    | 12 hour timeout. |\n|   3+   |  3 day timeout.  |"
 permissions = "Moderate Members"
 
 [[command]]
@@ -168,6 +168,16 @@ category = "Utility commands"
 name = "remind"
 args = "* `time` - The time until the bot should send the reminder - Coalescing Duration\n* `customMessage` - A custom message to attach to the reminder - Optional String"
 result = "Sets a reminder that will be sent in the channel the reminder was set in, once the set duration has passed"
+
+[[command]]
+category = "Utility commands"
+name = "reminders"
+result = "Sends an embed containing all the reminders you have set in that guild. If there are none, it returns a messages saying so."
+
+[[command]]
+category = "Utility commands"
+name = "remove-reminder"
+result = "Brings up a modal allowing you to specify the number of the reminder to delete. It is advised to use `/reminders` to find out what reminder number is."
 # End Utility commands
 
 # GitHub commands

--- a/docs/commanddocs.toml
+++ b/docs/commanddocs.toml
@@ -181,13 +181,9 @@ result = "Allows the user to input the number ID of the reminder they would like
 
 [[command]]
 category = "Utility commands"
-name = "reminder remove-repeating"
-result = "Removes all repeating reminders for the user from the guild the command was executed in"
-
-[[command]]
-category = "Utility commands"
 name = "reminder remove-all"
-result = "Removes all reminders for the user from the guild the command was executed in."
+args = "* `type` - The type of reminder to remove all of, can be `repeating`, `non-repeating` or `all` - String Choice"
+result = "Removes all the specific `type` of reminders for the user from the guild the command was executed in."
 # End Utility commands
 
 # GitHub commands

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,10 +118,10 @@ These commands are for use by moderators. They utilize built-in permission check
 
 | Points |     Sanction     |
 |:------:|:----------------:|
-|   1    | None.            |
+|   1    |      None.       |
 |   2    | 3 hour timeout.  |
 |   3    | 12 hour timeout. |
-|   3+   | 3 day timeout.   |
+|   3+   |  3 day timeout.  |
 
 **Required Permissions**: `Moderate Members`
 
@@ -324,6 +324,30 @@ None
 * `customMessage` - A custom message to attach to the reminder - Optional String
 
 **Result**: Sets a reminder that will be sent in the channel the reminder was set in, once the set duration has passed
+
+**Required Permissions**: `None`
+
+**Command category**: `Utility commands`
+
+---
+
+### Name: `reminders`
+**Arguments**:
+None
+
+**Result**: Sends an embed containing all the reminders you have set in that guild. If there are none, it returns a messages saying so.
+
+**Required Permissions**: `None`
+
+**Command category**: `Utility commands`
+
+---
+
+### Name: `remove-reminder`
+**Arguments**:
+None
+
+**Result**: Brings up a modal allowing you to specify the number of the reminder to delete. It is advised to use `/reminders` to find out what reminder number is.
 
 **Required Permissions**: `None`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -318,7 +318,7 @@ None
 
 ---
 
-### Name: `remind`
+### Name: `reminder set`
 **Arguments**:
 * `time` - The time until the bot should send the reminder - Coalescing Duration
 * `customMessage` - A custom message to attach to the reminder - Optional String
@@ -331,7 +331,7 @@ None
 
 ---
 
-### Name: `reminders`
+### Name: `remind list`
 **Arguments**:
 None
 
@@ -343,11 +343,35 @@ None
 
 ---
 
-### Name: `remove-reminder`
+### Name: `reminder remove`
 **Arguments**:
 None
 
-**Result**: Brings up a modal allowing you to specify the number of the reminder to delete. It is advised to use `/reminders` to find out what reminder number is.
+**Result**: Allows the user to input the number ID of the reminder they would like to delete. It is advised to use `/reminder list` to find out what reminder id is.
+
+**Required Permissions**: `None`
+
+**Command category**: `Utility commands`
+
+---
+
+### Name: `reminder remove-repeating`
+**Arguments**:
+None
+
+**Result**: Removes all repeating reminders for the user from the guild the command was executed in
+
+**Required Permissions**: `None`
+
+**Command category**: `Utility commands`
+
+---
+
+### Name: `reminder remove-all`
+**Arguments**:
+None
+
+**Result**: Removes all reminders for the user from the guild the command was executed in.
 
 **Required Permissions**: `None`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -355,23 +355,11 @@ None
 
 ---
 
-### Name: `reminder remove-repeating`
-**Arguments**:
-None
-
-**Result**: Removes all repeating reminders for the user from the guild the command was executed in
-
-**Required Permissions**: `None`
-
-**Command category**: `Utility commands`
-
----
-
 ### Name: `reminder remove-all`
 **Arguments**:
-None
+* `type` - The type of reminder to remove all of, can be `repeating`, `non-repeating` or `all` - String Choice
 
-**Result**: Removes all reminders for the user from the guild the command was executed in.
+**Result**: Removes all the specific `type` of reminders for the user from the guild the command was executed in.
 
 **Required Permissions**: `None`
 

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RemindMe.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RemindMe.kt
@@ -254,14 +254,14 @@ class RemindMe : Extension() {
 	 * @since 3.3.4
 	 * @author NoComment1105
 	 */
-	private suspend fun userReminders(event: ChatInputCommandInteractionCreateEvent): String {
+	private suspend inline fun userReminders(event: ChatInputCommandInteractionCreateEvent): String {
 		val reminders = DatabaseHelper.getReminders()
 		var response = ""
 		reminders.forEach {
 			if (it.userId == event.interaction.user.id && it.guildId == guildFor(event)!!.id) {
 				response +=
-					"Reminder ID: ${it.id}\nTime set: ${it.initialSetTime.toDiscord(TimestampType.ShortDateTime)},\nTime until " +
-							"reminder: ${it.remindTime.toDiscord(TimestampType.RelativeTime)} (${
+					"Reminder ID: ${it.id}\nTime set: ${it.initialSetTime.toDiscord(TimestampType.ShortDateTime)},\n" +
+							"Time until reminder: ${it.remindTime.toDiscord(TimestampType.RelativeTime)} (${
 								it.remindTime.toDiscord(TimestampType.ShortDateTime)
 							}),\nCustom Message: ${
 								it.customMessage ?: "none"
@@ -282,7 +282,7 @@ class RemindMe : Extension() {
 	 * @since 3.3.2
 	 * @author NoComment1105
 	 */
-	private suspend fun postReminders() {
+	private suspend inline fun postReminders() {
 		val reminders = DatabaseHelper.getReminders()
 
 		reminders.forEach {

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RemindMe.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RemindMe.kt
@@ -36,10 +36,13 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
 
-// TODO Migrate the current DB reminders over to the new system
-/** The class that contains the reminding functions in the bot. */
+/**
+ * The class that contains the reminding functions in the bot.
+ * @since 3.3.2
+ */
 class RemindMe : Extension() {
 	override val name = "remind-me"
 
@@ -112,6 +115,12 @@ class RemindMe : Extension() {
 			}
 		}
 
+		/**
+		 * The command that allows users to see the reminders they have set in this server.
+		 *
+		 * @since 3.3.4
+		 * @author NoComment1105
+		 */
 		ephemeralSlashCommand {
 			name = "reminders"
 			description = "See the reminders you have set for yourself in this guild."
@@ -133,6 +142,11 @@ class RemindMe : Extension() {
 			}
 		}
 
+		/**
+		 * Remove reminder command. Brings up a modal to allow the user to specify the reminder to delete.
+		 * @author NoComment1105
+		 * @since 3.3.4
+		 */
 		unsafeSlashCommand {
 			name = "remove-reminder"
 			description = "Remove a reminder you have set yourself"
@@ -213,6 +227,13 @@ class RemindMe : Extension() {
 		}
 	}
 
+	/**
+	 * Collect a String of reminders that a user has for this guild and return it.
+	 *
+	 * @param event The event of from the slash command
+	 * @since 3.3.4
+	 * @author NoComment1105
+	 */
 	private suspend fun userReminders(event: ChatInputCommandInteractionCreateEvent): String {
 		val reminders = DatabaseHelper.getReminders()
 		var response = ""
@@ -250,11 +271,7 @@ class RemindMe : Extension() {
 				if (it.customMessage.isNullOrEmpty()) {
 					channel.createMessage {
 						content = if (it.repeating) {
-							"Repeating reminder for <@${it.userId}> set ${
-								it.initialSetTime.toDiscord(
-									TimestampType.RelativeTime
-								)
-							} at ${it.initialSetTime.toDiscord(TimestampType.ShortDateTime)}"
+							"Repeating reminder for <@${it.userId}>"
 						} else {
 							"Reminder for <@${it.userId}> set ${
 								it.initialSetTime.toDiscord(
@@ -276,15 +293,7 @@ class RemindMe : Extension() {
 				} else {
 					channel.createMessage {
 						content = if (it.repeating) {
-							"Repeating reminder for <@${it.userId}> set ${
-								it.initialSetTime.toDiscord(
-									TimestampType.RelativeTime
-								)
-							} at ${
-								it.initialSetTime.toDiscord(
-									TimestampType.ShortDateTime
-								)
-							}\n> ${it.customMessage}"
+							"Repeating reminder for <@${it.userId}>\n> ${it.customMessage}"
 						} else {
 							"Reminder for <@${it.userId}> set ${
 								it.initialSetTime.toDiscord(
@@ -312,7 +321,7 @@ class RemindMe : Extension() {
 						it.guildId,
 						it.userId,
 						it.channelId,
-						it.remindTime.plus(30.seconds),
+						it.remindTime.plus(1.days),
 						it.originalMessageUrl,
 						it.customMessage,
 						true,
@@ -339,9 +348,10 @@ class RemindMe : Extension() {
 			description = "Add a custom message to your reminder"
 		}
 
+		/** Whether the reminder should repeat daily or not. */
 		val repeating by defaultingBoolean {
 			name = "repeating"
-			description = "Would you like this reminder to repeat?"
+			description = "Would you like this reminder to repeat daily?"
 			defaultValue = false
 		}
 	}

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RemindMe.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RemindMe.kt
@@ -223,7 +223,7 @@ class RemindMe : Extension() {
 
 			ephemeralSubCommand(::RemoveAllArgs) {
 				name = "remove-all"
-				description = "Remove all repeating reminders you have set for this guild"
+				description = "Remove all of a specific type of reminder that you have set for this guild"
 
 				check {
 					anyGuild()
@@ -233,33 +233,53 @@ class RemindMe : Extension() {
 					val reminders = DatabaseHelper.getReminders()
 
 					reminders.forEach {
-						if (arguments.reminderType == "all") {
-							if (it.guildId == guild?.id && it.userId == user.id) {
-								DatabaseHelper.removeReminder(guild!!.id, user.id, it.id)
-								val messageId = Snowflake(it.originalMessageUrl.split("/")[6])
-								this@ephemeralSubCommand.kord.getGuild(it.guildId)!!
-									.getChannelOf<TextChannel>(it.channelId)
-									.getMessage(messageId).edit {
-										content = "${if (it.repeating) "Repeating" else ""} Reminder cancelled."
-									}
+						when (arguments.reminderType) {
+							"all" -> {
+								if (it.guildId == guild?.id && it.userId == user.id) {
+									DatabaseHelper.removeReminder(guild!!.id, user.id, it.id)
+									val messageId = Snowflake(it.originalMessageUrl.split("/")[6])
+									this@ephemeralSubCommand.kord.getGuild(it.guildId)!!
+										.getChannelOf<TextChannel>(it.channelId)
+										.getMessage(messageId).edit {
+											content = "${if (it.repeating) "Repeating" else ""} Reminder cancelled."
+										}
+								}
+
+								respond {
+									content = "Removed all your reminders for this guild."
+								}
 							}
 
-							respond {
-								content = "Removed all your reminders for this guild."
-							}
-						} else if (arguments.reminderType == "repeating") {
-							if (it.guildId == guild?.id && it.userId == user.id && it.repeating) {
-								DatabaseHelper.removeReminder(guild!!.id, user.id, it.id)
-								val messageId = Snowflake(it.originalMessageUrl.split("/")[6])
-								this@ephemeralSubCommand.kord.getGuild(it.guildId)!!
-									.getChannelOf<TextChannel>(it.channelId)
-									.getMessage(messageId).edit {
-										content = "Repeating Reminder cancelled."
-									}
+							"repeating" -> {
+								if (it.guildId == guild?.id && it.userId == user.id && it.repeating) {
+									DatabaseHelper.removeReminder(guild!!.id, user.id, it.id)
+									val messageId = Snowflake(it.originalMessageUrl.split("/")[6])
+									this@ephemeralSubCommand.kord.getGuild(it.guildId)!!
+										.getChannelOf<TextChannel>(it.channelId)
+										.getMessage(messageId).edit {
+											content = "Repeating Reminder cancelled."
+										}
+								}
+
+								respond {
+									content = "Removed all your repeating reminders for this guild."
+								}
 							}
 
-							respond {
-								content = "Removed all your repeating reminders for this guild."
+							"non-repeating" -> {
+								if (it.guildId == guild?.id && it.userId == user.id && !it.repeating) {
+									DatabaseHelper.removeReminder(guild!!.id, user.id, it.id)
+									val messageId = Snowflake(it.originalMessageUrl.split("/")[6])
+									this@ephemeralSubCommand.kord.getGuild(it.guildId)!!
+										.getChannelOf<TextChannel>(it.channelId)
+										.getMessage(messageId).edit {
+											content = "Reminder cancelled."
+										}
+								}
+
+								respond {
+									content = "Removed all your non-repeating reminders for this guild."
+								}
 							}
 						}
 					}
@@ -427,6 +447,7 @@ class RemindMe : Extension() {
 			val list = ArrayList<String>()
 			list.add("repeating")
 			list.add("all")
+			list.add("non-repeating")
 
 			list.forEach {
 				choices[it] = it

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -418,7 +418,7 @@ object DatabaseHelper {
 	 *
 	 * @since 3.3.2
 	 * @author NoComment1105
-	*/
+	 */
 	suspend fun setReminder(
 		initialSetTime: Instant,
 		inputGuildId: Snowflake,
@@ -426,7 +426,8 @@ object DatabaseHelper {
 		inputChannelId: Snowflake,
 		remindTime: Instant,
 		originalMessageUrl: String,
-		customMessage: String?
+		customMessage: String?,
+		repeating: Boolean
 	) {
 		val collection = database.getCollection<RemindMeData>()
 		collection.insertOne(
@@ -437,7 +438,8 @@ object DatabaseHelper {
 				inputChannelId,
 				remindTime,
 				originalMessageUrl,
-				customMessage
+				customMessage,
+				repeating
 			)
 		)
 	}
@@ -452,12 +454,18 @@ object DatabaseHelper {
 	 * @since 3.3.2
 	 * @author NoComment1105
 	 */
-	suspend fun removeReminder(initialSetTime: Instant, inputGuildId: Snowflake, inputUserId: Snowflake) {
+	suspend fun removeReminder(
+        initialSetTime: Instant,
+        inputGuildId: Snowflake,
+        inputUserId: Snowflake,
+        remindTime: Instant
+    ) {
 		val collection = database.getCollection<RemindMeData>()
 		collection.deleteOne(
 			RemindMeData::initialSetTime eq initialSetTime,
 			RemindMeData::guildId eq inputGuildId,
-			RemindMeData::userId eq inputUserId
+			RemindMeData::userId eq inputUserId,
+			RemindMeData::remindTime eq remindTime
 		)
 	}
 
@@ -606,6 +614,7 @@ data class GalleryChannelData(
  * @param remindTime The time the user would like to be reminded at
  * @param originalMessageUrl The URL to the original message that set the reminder
  * @param customMessage A custom message to attach to the reminder
+ * @param repeating Whether the reminder should repeat
  *
  * @since 3.3.2
  */
@@ -617,5 +626,6 @@ data class RemindMeData(
 	val channelId: Snowflake,
 	val remindTime: Instant,
 	val originalMessageUrl: String,
-	val customMessage: String?
+	val customMessage: String?,
+	val repeating: Boolean
 )

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -427,7 +427,8 @@ object DatabaseHelper {
 		remindTime: Instant,
 		originalMessageUrl: String,
 		customMessage: String?,
-		repeating: Boolean
+		repeating: Boolean,
+		id: Int
 	) {
 		val collection = database.getCollection<RemindMeData>()
 		collection.insertOne(
@@ -439,7 +440,8 @@ object DatabaseHelper {
 				remindTime,
 				originalMessageUrl,
 				customMessage,
-				repeating
+				repeating,
+				id
 			)
 		)
 	}
@@ -447,25 +449,23 @@ object DatabaseHelper {
 	/**
 	 * Removes old reminders from the Database.
 	 *
-	 * @param initialSetTime The time the reminder was set
 	 * @param inputGuildId The ID of the guild the reminder was set in
 	 * @param inputUserId The ID of the user the reminder was set by
+	 * @param id The numerical ID of the reminder
 	 *
 	 * @since 3.3.2
 	 * @author NoComment1105
 	 */
 	suspend fun removeReminder(
-        initialSetTime: Instant,
         inputGuildId: Snowflake,
         inputUserId: Snowflake,
-        remindTime: Instant
+        id: Int
     ) {
 		val collection = database.getCollection<RemindMeData>()
 		collection.deleteOne(
-			RemindMeData::initialSetTime eq initialSetTime,
 			RemindMeData::guildId eq inputGuildId,
 			RemindMeData::userId eq inputUserId,
-			RemindMeData::remindTime eq remindTime
+			RemindMeData::id eq id
 		)
 	}
 
@@ -627,5 +627,6 @@ data class RemindMeData(
 	val remindTime: Instant,
 	val originalMessageUrl: String,
 	val customMessage: String?,
-	val repeating: Boolean
+	val repeating: Boolean,
+	val id: Int
 )


### PR DESCRIPTION
This PR allows users to create repeating reminders that will remind the user at the same time each day. It allows users to delete reminders when they no longer want them, making use of a modal, since buttons made deleting very difficult. We shorted the reminder time down to 30 seconds to improve accuracy with shorter reminders.
It also re formats the messages a little bit to contain the custom message that will be sent with the reminder.

Another PR will be prepared on top of this PR for migrating the current database values to a the new system.