### PR TITLE
Fix log uploading in threads

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/api/pluralkit/PluralKit.kt
@@ -21,9 +21,9 @@ internal const val PK_API_URL = "https://api.pluralkit.me/v2"
 /** The URL of messages from the [PluralKit API](https://pluralkit.me/api). */
 internal const val MESSAGE_URL = "$PK_API_URL/messages/{id}"
 
-object PluralKit {
+const val PK_API_DELAY: Long = 500
 
-	const val PK_API_DELAY: Long = 500
+object PluralKit {
 
 	/** The client used for querying values from the API. */
 	private val client = HttpClient {
@@ -46,7 +46,7 @@ object PluralKit {
 	 * @author NoComment1105
 	 * @since 3.3.0
 	 */
-	suspend fun isProxied(id: Snowflake) = isProxied(id.toString())
+	suspend fun isProxied(id: Snowflake?) = isProxied(id.toString())
 
 	/**
 	 * Using a provided message ID, we call [getProxiedMessageAuthorId] to find out the author of the message.
@@ -71,7 +71,10 @@ object PluralKit {
 	 * @author NoComment1105
 	 * @since 3.3.0
 	 */
-	 private suspend inline fun isProxied(id: String): Boolean {
+	 private suspend inline fun isProxied(id: String?): Boolean {
+		if (id.isNullOrEmpty()) {
+			return false
+		}
 		val url = MESSAGE_URL.replace("{id}", id)
 
 		var isProxied = false

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -10,13 +10,16 @@ import com.kotlindiscord.kord.extensions.extensions.event
 import com.kotlindiscord.kord.extensions.sentry.tag
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.utils.download
+import com.kotlindiscord.kord.extensions.utils.isNullOrBot
 import dev.kord.common.entity.ButtonStyle
 import dev.kord.common.entity.Permission
 import dev.kord.common.entity.Permissions
+import dev.kord.core.behavior.channel.asChannelOf
 import dev.kord.core.behavior.channel.createEmbed
 import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.behavior.edit
 import dev.kord.core.entity.Message
+import dev.kord.core.entity.channel.TextChannel
 import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.rest.builder.message.create.embed
 import dev.kord.rest.builder.message.modify.actionRow
@@ -27,11 +30,15 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.readBytes
 import io.ktor.http.Parameters
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.toList
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.botHasChannelPerms
+import net.irisshaders.lilybot.utils.configPresent
 import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.util.zip.GZIPInputStream
@@ -62,9 +69,31 @@ class LogUploading : Extension() {
 					event.message.channel.id,
 					Permissions(Permission.SendMessages, Permission.EmbedLinks)
 				)
+				configPresent()
+				failIf {
+					event.message.author.isNullOrBot()
+				}
 			}
 			action {
+				val config = DatabaseHelper.getConfig(event.guildId!!)!!
+				var deferUploadUntilThread = false
+				if (config.supportChannel != null && event.message.channel.id == config.supportChannel) {
+					deferUploadUntilThread = true
+				}
+
 				val eventMessage = event.message.asMessageOrNull() // Get the message
+				var uploadChannel = eventMessage.channel.asChannel()
+
+				if (deferUploadUntilThread) {
+					delay(1500) // Delay to allow for thread creation
+					val threads = eventMessage.channel.asChannelOf<TextChannel>().activeThreads.toList()
+					threads.forEach {
+						if (it.name.contains(eventMessage.author!!.username)) {
+							uploadChannel = it
+						}
+					}
+				}
+
 				eventMessage.attachments.forEach { attachment ->
 					val attachmentFileName = attachment.filename
 					val attachmentFileExtension = attachmentFileName.substring(
@@ -92,7 +121,7 @@ class LogUploading : Extension() {
 						val necText = "at Not Enough Crashes"
 						val indexOfNECText = builder.indexOf(necText)
 						if (indexOfNECText != -1) {
-							eventMessage.channel.createEmbed {
+							uploadChannel.createEmbed {
 								title = "Not Enough Crashes detected in logs"
 								description = "Not Enough Crashes (NEC) is well known to cause issues and often " +
 										"makes the debugging process more difficult. " +
@@ -108,7 +137,7 @@ class LogUploading : Extension() {
 							// Ask the user if they're ok with uploading their log to a paste site
 							var confirmationMessage: Message? = null
 
-							confirmationMessage = eventMessage.channel.createMessage {
+							confirmationMessage = uploadChannel.createMessage {
 								embed {
 									title = "Do you want to upload this file to mclo.gs?"
 									description =
@@ -133,7 +162,7 @@ class LogUploading : Extension() {
 												// Delete the confirmation and proceed to upload
 												confirmationMessage!!.delete()
 
-												val uploadMessage = eventMessage.channel.createEmbed {
+												val uploadMessage = uploadChannel.createEmbed {
 													title = "Uploading `$attachmentFileName` to mclo.gs..."
 													footer {
 														text = "Uploaded by ${eventMessage.author?.tag}"

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/LogUploading.kt
@@ -14,12 +14,13 @@ import com.kotlindiscord.kord.extensions.utils.isNullOrBot
 import dev.kord.common.entity.ButtonStyle
 import dev.kord.common.entity.Permission
 import dev.kord.common.entity.Permissions
-import dev.kord.core.behavior.channel.asChannelOf
 import dev.kord.core.behavior.channel.createEmbed
 import dev.kord.core.behavior.channel.createMessage
 import dev.kord.core.behavior.edit
+import dev.kord.core.behavior.getChannelOf
 import dev.kord.core.entity.Message
-import dev.kord.core.entity.channel.TextChannel
+import dev.kord.core.entity.channel.MessageChannel
+import dev.kord.core.entity.channel.thread.TextChannelThread
 import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.rest.builder.message.create.embed
 import dev.kord.rest.builder.message.modify.actionRow
@@ -31,7 +32,6 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.readBytes
 import io.ktor.http.Parameters
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.toList
 import kotlinx.datetime.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -86,10 +86,11 @@ class LogUploading : Extension() {
 
 				if (deferUploadUntilThread) {
 					delay(1500) // Delay to allow for thread creation
-					val threads = eventMessage.channel.asChannelOf<TextChannel>().activeThreads.toList()
-					threads.forEach {
-						if (it.name.contains(eventMessage.author!!.username)) {
-							uploadChannel = it
+					DatabaseHelper.getOwnerThreads(event.member!!.id).forEach {
+						if (event.getGuild()!!.getChannelOf<TextChannelThread>(it.threadId).parentId ==
+							config.supportChannel
+						) {
+							uploadChannel = event.getGuild()!!.getChannel(it.threadId) as MessageChannel
 						}
 					}
 				}

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/MessageDelete.kt
@@ -10,6 +10,7 @@ import dev.kord.core.entity.channel.TextChannel
 import dev.kord.core.event.message.MessageDeleteEvent
 import kotlinx.coroutines.delay
 import kotlinx.datetime.Clock
+import net.irisshaders.lilybot.api.pluralkit.PK_API_DELAY
 import net.irisshaders.lilybot.api.pluralkit.PluralKit
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.configPresent
@@ -35,7 +36,7 @@ class MessageDelete : Extension() {
 			}
 
 			action {
-				delay(PluralKit.PK_API_DELAY) // Allow the PK API to catch up
+				delay(PK_API_DELAY) // Allow the PK API to catch up
 				if (event.message?.author?.isBot == true) return@action
 
 				val config = DatabaseHelper.getConfig(event.guild!!.id)!!
@@ -55,9 +56,10 @@ class MessageDelete : Extension() {
 				val messageLocation = event.channel.id.value
 
 				// Avoid logging messages proxied by PluralKit, since these messages aren't "actually deleted"
-				if (PluralKit.isProxied(eventMessage!!.id)) {
+				if (PluralKit.isProxied(eventMessage?.id)) {
 					return@action
 				}
+				if (eventMessage == null) return@action
 
 				messageLog?.createEmbed {
 					color = DISCORD_PINK

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
@@ -29,6 +29,7 @@ import dev.kord.core.event.message.MessageCreateEvent
 import dev.kord.core.exception.EntityNotFoundException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.last
+import net.irisshaders.lilybot.api.pluralkit.PK_API_DELAY
 import net.irisshaders.lilybot.api.pluralkit.PluralKit
 import net.irisshaders.lilybot.utils.DatabaseHelper
 import net.irisshaders.lilybot.utils.configPresent
@@ -68,7 +69,7 @@ class ThreadInviter : Extension() {
 				}
 			}
 			action {
-				delay(PluralKit.PK_API_DELAY) // Allow the PK API to catch up
+				delay(PK_API_DELAY) // Allow the PK API to catch up
 				val config = DatabaseHelper.getConfig(event.guildId!!)!!
 
 				config.supportTeam ?: return@action

--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RoleMenu.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/RoleMenu.kt
@@ -405,7 +405,9 @@ class RoleMenu : Extension() {
 		event<ButtonInteractionCreateEvent> {
 			check {
 				anyGuild()
-				event.interaction.componentId.contains("role-menu")
+				failIfNot {
+					event.interaction.componentId.contains("role-menu")
+				}
 			}
 			action {
 				val data = DatabaseHelper.getRoleData(event.interaction.message.id)


### PR DESCRIPTION
Fixes #174 by checking if the channel is the configured support channel and the waiting until a thread is created for that message, before uploading the log in the support channe,
Also fixes a couple of issues elsewhere with null pointers here and there