### PR TITLE
Add configurable thread message

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/events/ThreadInviter.kt
@@ -124,12 +124,18 @@ class ThreadInviter : Extension() {
 
 					DatabaseHelper.setThreadOwner(thread.id, userId)
 
-					val editMessage = thread.createMessage("edit message")
+					val threadMessageData = DatabaseHelper.getThreadMessageData(guild.id)
 
-					editMessage.edit {
-						this.content =
+					if (threadMessageData != null) {
+						thread.createMessage(
+							threadMessageData.message.replace("\\n", "\n")
+								.replace("@user", event.member!!.asUser().mention)
+						)
+					} else {
+						thread.createMessage(
 							user.asUser().mention + ", the " + event.getGuild()
 								?.getRole(config.supportTeam)?.mention + " will be with you shortly!"
+						)
 					}
 
 					if (textChannel.messages.last().author?.id == kord.selfId) {

--- a/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/utils/DatabaseHelper.kt
@@ -60,6 +60,28 @@ object DatabaseHelper {
 	}
 
 	/**
+	 * Gets the thread message for the provided [inputGuildId] from the database.
+	 *
+	 * @param inputGuildId The ID of the guild the command was run in
+	 * @return null or the result from the database
+	 */
+	suspend fun getThreadMessageData(inputGuildId: Snowflake): ThreadMessageData? {
+		val collection = database.getCollection<ThreadMessageData>()
+		return collection.findOne(ThreadMessageData::guildId eq inputGuildId)
+	}
+
+	/**
+	 * Updates the provided [threadMessageData] in the database.
+	 *
+	 * @param threadMessageData The thread message.
+	 */
+	suspend fun setThreadMessageData(threadMessageData: ThreadMessageData) {
+		val collection = database.getCollection<ThreadMessageData>()
+		collection.deleteOne(ThreadMessageData::guildId eq threadMessageData.guildId)
+		collection.insertOne(threadMessageData)
+	}
+
+	/**
 	 * Gets the number of points the provided [inputUserId] has in the provided [inputGuildId] from the database.
 	 *
 	 * @param inputUserId The ID of the user to get the point value for
@@ -541,6 +563,18 @@ data class ConfigData(
 	val joinChannel: Snowflake,
 	val supportChannel: Snowflake?,
 	val supportTeam: Snowflake?,
+)
+
+/**
+ * The data for thread messages.
+ *
+ * @param guildId The ID of the guild the config is for
+ * @param message The message
+ */
+@Serializable
+data class ThreadMessageData(
+	val guildId: Snowflake,
+	val message: String
 )
 
 /**


### PR DESCRIPTION
Closes #138

I created this PR, since I added this feature for my fork of the bot for the Simple Voice Chat Discord server.
I've seen issue #138, so I thought I might share this with you guys.
Its also completely fine if you don't want this added or have other plans on implementing this.

If you have any suggestions for improvement just let me know and I'll try to implement them.

This PR adds the command `/config threadmessage <your-message>`.
You can add newlines with `\n` and ping the creator of the thread with `@user`.
If you haven't set a custom thread message, the bot will fall back to the default message.
