### PR TITLE
Fix misleading ping message

### DIFF
--- a/src/main/kotlin/net/irisshaders/lilybot/extensions/util/PublicUtilities.kt
+++ b/src/main/kotlin/net/irisshaders/lilybot/extensions/util/PublicUtilities.kt
@@ -58,7 +58,7 @@ class PublicUtilities : Extension() {
 						timestamp = Clock.System.now()
 
 						field {
-							name = "Your Ping with Lily is:"
+							name = "Lily's Ping to Discord is:"
 							value = "**$averagePing**"
 							inline = true
 						}


### PR DESCRIPTION
### Linked Issues
It's not an issue, but <https://canary.discord.com/channels/774352792659820594/876597935092170794/1001020420503375872>

### Proposed Changes
Fixes the misleading message to say that it's the ping to Discord.
