### PR TITLE
Add an option to publicly log moderation actions

### DIFF
--- a/docs/commanddocs.toml
+++ b/docs/commanddocs.toml
@@ -13,7 +13,7 @@ permissions = "Manage Guild"
 [[command]]
 category = "Administration commands"
 name = "config moderation"
-args = "* `enable` - Whether to enable the moderation system or not - Boolean\n* `moderatorRole` - The role of the guild moderators, used for pinging in message logs and adding to threads\n* `modActionLog` - The channel to store the moderation actions in - Channel"
+args = "* `enable` - Whether to enable the moderation system or not - Boolean\n* `moderatorRole` - The role of the guild moderators, used for pinging in message logs and adding to threads\n* `modActionLog` - The channel to store the moderation actions in - Channel\n*`log-publicly` - Whether to log moderation actions in the channel they were run in as well as the action log - Optional Boolean"
 result = "The config is set for moderation."
 permissions = "Manage Guild"
 

--- a/docs/commanddocs.toml
+++ b/docs/commanddocs.toml
@@ -13,7 +13,7 @@ permissions = "Manage Guild"
 [[command]]
 category = "Administration commands"
 name = "config moderation"
-args = "* `enable` - Whether to enable the moderation system or not - Boolean\n* `moderator-role` - The role of the guild moderators, used for pinging in message logs and adding to threads\n* `mod-action-log` - The channel to store the moderation actions in - Channel\n*`log-publicly` - Whether to log moderation actions in the channel they were run in as well as the action log - Optional Boolean"
+args = "* `enable` - Whether to enable the moderation system or not - Boolean\n* `moderator-role` - The role of the guild moderators, used for pinging in message logs and adding to threads\n* `mod-action-log` - The channel to store the moderation actions in - Channel\n*`log-publicly` - Whether to log moderation actions in the channel they were run in as well as the action log. Defaults to false - Optional Boolean"
 result = "The config is set for moderation."
 permissions = "Manage Guild"
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,6 +28,7 @@ These are commands for the maintenance of LilyBot. The can only be run by Server
 * `enable` - Whether to enable the moderation system or not - Boolean
 * `moderatorRole` - The role of the guild moderators, used for pinging in message logs and adding to threads
 * `modActionLog` - The channel to store the moderation actions in - Channel
+*`log-publicly` - Whether to log moderation actions in the channel they were run in as well as the action log - Optional Boolean
 
 **Result**: The config is set for moderation.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,7 +28,7 @@ These are commands for the maintenance of LilyBot. The can only be run by Server
 * `enable` - Whether to enable the moderation system or not - Boolean
 * `moderator-role` - The role of the guild moderators, used for pinging in message logs and adding to threads
 * `mod-action-log` - The channel to store the moderation actions in - Channel
-*`log-publicly` - Whether to log moderation actions in the channel they were run in as well as the action log - Optional Boolean
+*`log-publicly` - Whether to log moderation actions in the channel they were run in as well as the action log. Defaults to false - Optional Boolean
 
 **Result**: The config is set for moderation.
 

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/entities/Config.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/entities/Config.kt
@@ -39,6 +39,7 @@ data class ModerationConfigData(
 	val enabled: Boolean,
 	val channel: Snowflake?,
 	val role: Snowflake?,
+	val publicLogging: Boolean?,
 )
 
 /**

--- a/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/config/configV1.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/database/migrations/config/configV1.kt
@@ -55,7 +55,7 @@ suspend fun configV1(mainDb: CoroutineDatabase, configDb: CoroutineDatabase) {
 		loggingConfig.insertOne(LoggingConfigData(guildId, true, oldLoggingData[0], true, oldLoggingData[1]))
 	}
 	if (oldModerationData.isNotEmpty()) {
-		moderationConfig.insertOne(ModerationConfigData(guildId, true, oldModerationData[0], oldModerationData[1]))
+		moderationConfig.insertOne(ModerationConfigData(guildId, true, oldModerationData[0], oldModerationData[1], false))
 	}
 	if (oldSupportData[0] != null) {
 		supportConfig.insertOne(SupportConfigData(guildId, true, oldSupportData[0]!!, oldSupportData[1]!!, null))

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/Config.kt
@@ -252,6 +252,15 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 				}
 			}
 
+			if (getModerationChannelWithPerms(
+					guild!!.asGuild(),
+					arguments.modActionLog?.id,
+					ConfigType.MODERATION
+				)?.id != arguments.modActionLog?.id
+			) {
+				return@action
+			}
+
 			ModerationConfigCollection().setConfig(
 				ModerationConfigData(
 					guild!!.id,
@@ -264,7 +273,7 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 
 			checkChannel(
 				guild,
-				arguments.modActionLog!!.id,
+				arguments.modActionLog?.id,
 				interactionResponse
 			)?.createMessage {
 				embed {
@@ -436,7 +445,7 @@ suspend fun Config.configCommand() = unsafeSlashCommand {
 			suspend fun logClear() {
 				checkChannel(
 					guild,
-					ModerationConfigCollection().getConfig(guild!!.id)!!.channel!!,
+					ModerationConfigCollection().getConfig(guild!!.id)!!.channel,
 					interactionResponse
 				)?.createMessage {
 					embed {
@@ -661,12 +670,13 @@ class ClearArgs : Arguments() {
  */
 suspend inline fun checkChannel(
 	guild: GuildBehavior?,
-	channelIdToCheck: Snowflake,
+	channelIdToCheck: Snowflake?,
 	interactionResponse: FollowupPermittingInteractionResponseBehavior
 ): GuildMessageChannel? {
 	val toReturn: GuildMessageChannel?
 	if (ModerationConfigCollection().getConfig(guild!!.id) == null ||
-		!ModerationConfigCollection().getConfig(guild.id)!!.enabled
+		!ModerationConfigCollection().getConfig(guild.id)!!.enabled ||
+				channelIdToCheck == null
 	) {
 		toReturn = getModerationChannelWithPerms(
 			guild.asGuild(),

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/ConfigOptions.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/config/ConfigOptions.kt
@@ -24,6 +24,9 @@ enum class ConfigOptions {
 	/** The option that stores the action logging channel. */
 	ACTION_LOG,
 
+	/** The option that stores whether to log a moderation action publicly. */
+	LOG_PUBLICLY,
+
 	/** The option that stores whether the logging config is enabled or not. */
 	MESSAGE_LOGGING_ENABLED,
 

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TemporaryModeration.kt
@@ -116,6 +116,13 @@ class TemporaryModeration : Extension() {
 					}
 					color = DISCORD_BLACK
 				}
+
+				if (config.publicLogging != null && config.publicLogging == true) {
+					channel.createEmbed {
+						title = "$messageAmount messages have been cleared."
+						color = DISCORD_BLACK
+					}
+				}
 			}
 		}
 
@@ -275,6 +282,14 @@ class TemporaryModeration : Extension() {
 					embed.image = null
 					actionLog.createMessage { embeds.add(embed) }
 				}
+
+				if (config.publicLogging != null && config.publicLogging == true) {
+					channel.createEmbed {
+						title = "Warning"
+						description = "${userArg.mention} has been warned by a moderator"
+						color = DISCORD_BLACK
+					}
+				}
 			}
 		}
 
@@ -432,6 +447,20 @@ class TemporaryModeration : Extension() {
 				} catch (e: KtorRequestException) {
 					embed.image = null
 					actionLog.createMessage { embeds.add(embed) }
+				}
+
+				if (config.publicLogging != null && config.publicLogging == true) {
+					channel.createEmbed {
+						title = "Timeout"
+						description = "${userArg.mention} was timed out by a moderator"
+						color = DISCORD_BLACK
+						field {
+							name = "Duration:"
+							value = duration.toDiscord(TimestampType.Default) + " (" + arguments.duration.toString()
+								.replace("PT", "") + ")"
+							inline = false
+						}
+					}
 				}
 			}
 		}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TerminalModeration.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/extensions/moderation/TerminalModeration.kt
@@ -134,6 +134,14 @@ class TerminalModeration : Extension() {
 					embed.image = null
 					actionLog.createMessage { embeds.add(embed) }
 				}
+
+				if (config.publicLogging != null && config.publicLogging == true) {
+					channel.createEmbed {
+						title = "Banned a user"
+						description = "${userArg.mention} has been banned!"
+						color = DISCORD_BLACK
+					}
+				}
 			}
 		}
 
@@ -283,6 +291,13 @@ class TerminalModeration : Extension() {
 					actionLog.createMessage { embeds.add(embed) }
 				}
 
+				if (config.publicLogging != null && config.publicLogging == true) {
+					channel.createEmbed {
+						title = "Soft-Banned a user"
+						description = "${userArg.mention} has been soft-banned!"
+					}
+				}
+
 				// Unban the user, as you're supposed to in soft-ban
 				guild?.unban(userArg.id)
 			}
@@ -357,6 +372,13 @@ class TerminalModeration : Extension() {
 				} catch (e: KtorRequestException) {
 					embed.image = null
 					actionLog.createMessage { embeds.add(embed) }
+				}
+
+				if (config.publicLogging != null && config.publicLogging == true) {
+					channel.createEmbed {
+						title = "Kicked a user"
+						description = "${userArg.mention} has been kicked!"
+					}
 				}
 			}
 		}

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -155,6 +155,19 @@ suspend inline fun CheckContext<*>.configPresent(vararg configOptions: ConfigOpt
 				}
 			}
 
+			ConfigOptions.LOG_PUBLICLY -> {
+				val moderationConfig = ModerationConfigCollection().getConfig(guildFor(event)!!.id)
+				if (moderationConfig == null) {
+					fail("Unable to access moderation config for this guild! Please inform a member of staff.")
+					break
+				} else if (moderationConfig.publicLogging == null) {
+					fail("Public logging has not been enabled for this guild!")
+					break
+				} else {
+					pass()
+				}
+			}
+
 			ConfigOptions.MESSAGE_LOGGING_ENABLED -> {
 				val loggingConfig = LoggingConfigCollection().getConfig(guildFor(event)!!.id)
 				if (loggingConfig == null) {

--- a/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
+++ b/src/main/kotlin/org/hyacinthbots/lilybot/utils/_Utils.kt
@@ -445,11 +445,11 @@ suspend inline fun getFirstUsableChannel(inputGuild: Guild): GuildMessageChannel
  */
 suspend inline fun <T : FollowupPermittingInteractionResponseBehavior?> getModerationChannelWithPerms(
 	inputGuild: Guild,
-	targetChannel: Snowflake,
+	targetChannel: Snowflake?,
 	configType: ConfigType,
 	interactionResponse: T? = null
 ): GuildMessageChannel? {
-	val channel = inputGuild.getChannelOfOrNull<GuildMessageChannel>(targetChannel)
+	val channel = targetChannel?.let { inputGuild.getChannelOfOrNull<GuildMessageChannel>(it) }
 
 	// Check each permission in a separate check because all in one expects all to be there or not. This allows for
 	// some permissions to be false and some to be true while still producing the correct result.
@@ -509,7 +509,7 @@ suspend inline fun <T : FollowupPermittingInteractionResponseBehavior?> getModer
  */
 suspend inline fun getModerationChannelWithPerms(
 	inputGuild: Guild,
-	targetChannel: Snowflake,
+	targetChannel: Snowflake?,
 	configType: ConfigType
 ): GuildMessageChannel? =
 	getModerationChannelWithPerms(inputGuild, targetChannel, configType, null)


### PR DESCRIPTION
Provides simple and reduced-info embeds when running moderation commands in a channel, as per a past request from @wafflecoffee

#208

![image](https://user-images.githubusercontent.com/67918617/187997492-1ad4fc48-7c45-4751-8693-3af3dbd875b5.png)